### PR TITLE
feat: Claude Code workflow の追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.issue.user.login == 'kokuyouwind') ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.user.login == 'kokuyouwind') ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.user.login == 'kokuyouwind') ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && github.event.issue.user.login == 'kokuyouwind')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*),Skill(*)"'


### PR DESCRIPTION
## 概要
Claude Code の GitHub Actions workflow を追加

## 変更の背景
- このリポジトリには claude.yml workflow がなく、@claude メンションで Claude を呼び出せなかった
- issue-resolver スキルを使うために Skill ツールの許可が必要

## 変更詳細
- `.github/workflows/claude.yml` を追加
- kokuyouwind が作成した Issue/PR のみで Claude が動作するよう制限
- `--allowed-tools` に `Skill(*)` を追加してスキル呼び出しを許可