### PR TITLE
feat: プラグインマーケットプレイスとプラグイン設定を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,3 +38,13 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: '--allowed-tools "Bash(gh issue:*),Bash(gh label:*),Bash(gh pr:*),Skill(*)"'
+
+          # Plugin marketplace configuration
+          # Note: .claude/settings.json is not automatically loaded in GitHub Actions
+          plugin_marketplaces: |
+            https://github.com/kokuyouwind/claude-plugins.git
+
+          # Install required plugins for development workflow
+          plugins: |
+            dev-guidelines@kokuyouwind-plugins
+            issue-resolver@kokuyouwind-plugins


### PR DESCRIPTION
## 概要

GitHub ActionsでClaude Codeがdev-guidelinesおよびissue-resolverプラグインを使用できるよう、プラグイン設定を追加

## 変更の背景

`.claude/settings.json`に定義されたマーケットプレイスやプラグイン設定は、GitHub Actions環境では自動的に読み込まれない。そのため、issue-resolverスキルを使用したIssue解決の自動化が機能しなかった。

## 変更詳細

`.github/workflows/claude.yml`に以下を追加：

1. **plugin_marketplaces**: kokuyouwind-pluginsマーケットプレイスを登録
2. **plugins**: dev-guidelinesとissue-resolverプラグインをインストール

これにより、issue-resolverスキルが使用可能になり、auto-resolverによるIssue解決が正常に動作する。

## 参考

- claude-plugins#46（同様の修正PR）