### PR TITLE
feat: implement Phase 1-3 core comparison logic, metrics, and type system

### DIFF
--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -32,16 +32,16 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 ##### MethodNode (`lib/type_eval_rb/comparison_tree/method_node.rb`)
 - ✅ Method name comparison
 - ✅ Required positional parameters comparison
+- ✅ Optional positional parameters (required: false)
+- ✅ Keyword parameters (required and optional, param_type: :keyword)
+- ✅ Rest parameters (positional and keyword, rest: true)
+- ✅ Block parameters (TypeNode wrapping RBS::Types::Block)
+- ✅ Singleton method support (kind: :singleton or :instance)
 - ✅ Return type comparison
 - ✅ Pretty-print support
-- ✅ Metrics: `count_leaf` and `count_matches` (sum of parameters + return_type)
-- ❌ **Missing**: Optional parameters
-- ❌ **Missing**: Rest parameters (`*args`)
-- ❌ **Missing**: Keyword parameters
-- ❌ **Missing**: Block parameters
+- ✅ Metrics: `count_leaf` and `count_matches` (sum of parameters + return_type + block)
 - ❌ **Missing**: Method overloading support
 - ❌ **Missing**: Visibility (public/private/protected)
-- ❌ **Missing**: Singleton method support (self.method_name)
 
 ##### InstanceVariableNode (`lib/type_eval_rb/comparison_tree/instance_variable_node.rb`)
 - ✅ Instance variable name comparison

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -66,6 +66,7 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
   - untyped (Bases::Any) matches everything
   - Nil type comparison
   - nil actual returns false (missing type)
+- ✅ Metrics: `count_leaf` (always 1) and `count_matches` (1 if matches?, else 0)
 - ❌ **Missing**: Union type handling
 - ❌ **Missing**: Intersection type handling
 - ❌ **Missing**: Optional type handling (`Integer?`)

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -178,8 +178,10 @@ Each feature implementation should include:
 - Edge case handling
 
 ### Integration Tests
-After core comparison logic is implemented:
-- Compare simple class definitions
+- ✅ `spec/integration/simple_comparison_spec.rb` - End-to-end test: fixture loading, tree structure, and metrics (count_leaf, count_matches, accuracy)
+- Fixtures: `spec/fixtures/integration/expected/` and `spec/fixtures/integration/actual/`
+
+Pending:
 - Compare inheritance hierarchies
 - Compare generic classes
 - Compare modules and interfaces

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -1,0 +1,184 @@
+# Implementation Status
+
+This document tracks the current implementation status of TypeEvalRb.
+
+## Overview
+
+TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It compares expected RBS type signatures against actual inferred types using a tree-based comparison structure.
+
+## Current Implementation (Implemented Features)
+
+### Core Data Structures
+
+#### ComparisonTree (`lib/type_eval_rb/comparison_tree.rb`)
+- ✅ Tree construction from two RBS environments (`from_envs`)
+- ✅ Pretty-print support
+- ❌ **Missing**: Metrics calculation (count_leaf, count_matches)
+
+#### Node Types
+
+##### ClassNode (`lib/type_eval_rb/comparison_tree/class_node.rb`)
+- ✅ Class type name comparison
+- ✅ Instance variable collection and comparison
+- ✅ Method collection and comparison
+- ✅ Construction from RBS AST declarations
+- ✅ Pretty-print support
+- ❌ **Missing**: Leaf counting and match counting
+- ❌ **Missing**: Inheritance comparison
+- ❌ **Missing**: Module mixins comparison (include/extend/prepend)
+- ❌ **Missing**: Class/singleton method distinction
+- ❌ **Missing**: Generic type parameters
+
+##### MethodNode (`lib/type_eval_rb/comparison_tree/method_node.rb`)
+- ✅ Method name comparison
+- ✅ Required positional parameters comparison
+- ✅ Return type comparison
+- ✅ Pretty-print support
+- ❌ **Missing**: Optional parameters
+- ❌ **Missing**: Rest parameters (`*args`)
+- ❌ **Missing**: Keyword parameters
+- ❌ **Missing**: Block parameters
+- ❌ **Missing**: Method overloading support
+- ❌ **Missing**: Visibility (public/private/protected)
+- ❌ **Missing**: Singleton method support (self.method_name)
+
+##### InstanceVariableNode (`lib/type_eval_rb/comparison_tree/instance_variable_node.rb`)
+- ✅ Instance variable name comparison
+- ✅ Type comparison via TypeNode
+- ✅ Pretty-print support
+- ❌ **Missing**: Leaf counting and match counting
+- ❌ **Missing**: Class instance variables (`self.@var`)
+
+##### ArgumentNode (`lib/type_eval_rb/comparison_tree/argument_node.rb`)
+- ✅ Parameter name storage
+- ✅ Type comparison via TypeNode
+- ✅ Pretty-print support
+- ❌ **Missing**: Optional parameter indicator
+- ❌ **Missing**: Rest parameter indicator
+- ❌ **Missing**: Keyword parameter indicator
+
+##### TypeNode (`lib/type_eval_rb/comparison_tree/type_node.rb`)
+- ✅ Expected vs Actual type storage
+- ✅ Basic type-to-string conversion (ClassInstance)
+- ✅ Pretty-print support
+- ❌ **Missing**: All type comparison logic
+- ❌ **Missing**: Union type handling
+- ❌ **Missing**: Intersection type handling
+- ❌ **Missing**: Optional type handling (`Integer?`)
+- ❌ **Missing**: Tuple type handling
+- ❌ **Missing**: Record type handling
+- ❌ **Missing**: Proc type handling
+- ❌ **Missing**: Generic type parameter handling
+- ❌ **Missing**: Literal type handling
+- ❌ **Missing**: Special types (self, instance, class, bool, void, etc.)
+
+### Environment Loading (`lib/type_eval_rb/environment.rb`)
+- ✅ Load RBS files from a directory path
+- ✅ Parse RBS with type name resolution
+- ✅ Filter class declarations by path
+- ❌ **Missing**: Interface loading
+- ❌ **Missing**: Module loading (currently treated same as classes)
+- ❌ **Missing**: Type alias loading
+- ❌ **Missing**: Constant and global variable loading
+
+### Test Coverage
+
+#### Unit Tests
+- ✅ Environment initialization and path loading
+- ✅ TypeNode initialization and pretty-print
+- ✅ ArgumentNode initialization and pretty-print
+- ✅ MethodNode initialization and pretty-print
+- ✅ ClassNode initialization and pretty-print
+- ✅ InstanceVariableNode initialization and pretty-print
+
+#### Test Fixtures
+Available examples in `spec/fixtures/examples/`:
+- `test/` - Basic class with method
+- `multi_file_test/` - Multiple classes across files
+- `user_factory/` - Factory pattern with instance variables
+- `fix_errors_user_factory/` - Same as above with error cases
+- `with_errors/` - Error handling test case
+- `bird/` - Inheritance example (Bird < Duck, Goose)
+- `dynamic_definitions/` - Dynamic method definitions
+- `namespace/` - Namespace handling
+
+## Missing Core Functionality
+
+### 1. Type Comparison Logic
+The TypeNode class stores expected and actual types but doesn't implement any comparison logic. Need to implement:
+- Exact match checking
+- Subtype/supertype relationship checking
+- Union/intersection type comparison
+- Generic type parameter matching
+- Handling of `untyped` (universal type)
+
+### 2. Metrics Calculation
+The base Node class defines `count_leaf` and `count_matches` but none of the subclasses implement them. These are essential for benchmarking:
+- `count_leaf`: Count total number of type comparisons
+- `count_matches`: Count number of matching types
+
+### 3. Advanced RBS Features
+Many RBS features are not yet supported:
+- Method overloading
+- Generic type parameters with variance and bounds
+- Interface definitions
+- Type aliases
+- Module mixins (include/extend/prepend)
+- Visibility modifiers
+- Attributes (attr_reader, attr_writer, attr_accessor)
+- Class variables and constants
+- Global variables
+- Proc types with self-type binding
+
+## Implementation Priority
+
+### Phase 1: Core Comparison Logic (High Priority)
+1. Implement type comparison in TypeNode
+2. Implement count_leaf and count_matches in all nodes
+3. Add basic metrics output
+
+### Phase 2: Method Signatures (High Priority)
+1. Support optional parameters
+2. Support keyword parameters
+3. Support rest parameters
+4. Support block parameters
+5. Support singleton methods
+
+### Phase 3: Type System Coverage (Medium Priority)
+1. Union types (`Integer | String`)
+2. Intersection types (`_Reader & _Writer`)
+3. Optional types (`Integer?`)
+4. Tuple types (`[Integer, String]`)
+5. Record types (`{ id: Integer, name: String }`)
+6. Generic type parameters
+
+### Phase 4: Advanced Features (Low Priority)
+1. Method overloading
+2. Interface definitions
+3. Type aliases
+4. Module mixins
+5. Attributes
+6. Proc types
+7. Variance and bounds for generics
+
+## Testing Strategy
+
+### Unit Tests
+Each feature implementation should include:
+- Initialization tests
+- Comparison logic tests
+- Metrics calculation tests
+- Edge case handling
+
+### Integration Tests
+After core comparison logic is implemented:
+- Compare simple class definitions
+- Compare inheritance hierarchies
+- Compare generic classes
+- Compare modules and interfaces
+
+### Benchmark Tests
+Using real-world RBS signatures:
+- Standard library classes (Array, Hash, String, etc.)
+- Popular gems
+- Complex type inference scenarios

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -13,7 +13,7 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 #### ComparisonTree (`lib/type_eval_rb/comparison_tree.rb`)
 - ✅ Tree construction from two RBS environments (`from_envs`)
 - ✅ Pretty-print support
-- ❌ **Missing**: Metrics calculation (count_leaf, count_matches)
+- ✅ Metrics: `count_leaf`, `count_matches`, `accuracy`
 
 #### Node Types
 
@@ -23,7 +23,7 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 - ✅ Method collection and comparison
 - ✅ Construction from RBS AST declarations
 - ✅ Pretty-print support
-- ❌ **Missing**: Leaf counting and match counting
+- ✅ Metrics: `count_leaf` and `count_matches`
 - ❌ **Missing**: Inheritance comparison
 - ❌ **Missing**: Module mixins comparison (include/extend/prepend)
 - ❌ **Missing**: Class/singleton method distinction
@@ -34,6 +34,7 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 - ✅ Required positional parameters comparison
 - ✅ Return type comparison
 - ✅ Pretty-print support
+- ✅ Metrics: `count_leaf` and `count_matches` (sum of parameters + return_type)
 - ❌ **Missing**: Optional parameters
 - ❌ **Missing**: Rest parameters (`*args`)
 - ❌ **Missing**: Keyword parameters
@@ -46,13 +47,14 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 - ✅ Instance variable name comparison
 - ✅ Type comparison via TypeNode
 - ✅ Pretty-print support
-- ❌ **Missing**: Leaf counting and match counting
+- ✅ Metrics: `count_leaf` and `count_matches` (delegated to TypeNode)
 - ❌ **Missing**: Class instance variables (`self.@var`)
 
 ##### ArgumentNode (`lib/type_eval_rb/comparison_tree/argument_node.rb`)
 - ✅ Parameter name storage
 - ✅ Type comparison via TypeNode
 - ✅ Pretty-print support
+- ✅ Metrics: `count_leaf` and `count_matches` (delegated to TypeNode)
 - ❌ **Missing**: Optional parameter indicator
 - ❌ **Missing**: Rest parameter indicator
 - ❌ **Missing**: Keyword parameter indicator

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -59,9 +59,13 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 
 ##### TypeNode (`lib/type_eval_rb/comparison_tree/type_node.rb`)
 - ✅ Expected vs Actual type storage
-- ✅ Basic type-to-string conversion (ClassInstance)
+- ✅ Basic type-to-string conversion (ClassInstance, Nil, Any/untyped)
 - ✅ Pretty-print support
-- ❌ **Missing**: All type comparison logic
+- ✅ Basic type comparison logic (`matches?` method)
+  - ClassInstance exact match
+  - untyped (Bases::Any) matches everything
+  - Nil type comparison
+  - nil actual returns false (missing type)
 - ❌ **Missing**: Union type handling
 - ❌ **Missing**: Intersection type handling
 - ❌ **Missing**: Optional type handling (`Integer?`)

--- a/.claude/docs/implementation-status.md
+++ b/.claude/docs/implementation-status.md
@@ -61,15 +61,20 @@ TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It c
 
 ##### TypeNode (`lib/type_eval_rb/comparison_tree/type_node.rb`)
 - ✅ Expected vs Actual type storage
-- ✅ Basic type-to-string conversion (ClassInstance, Nil, Any/untyped)
 - ✅ Pretty-print support
-- ✅ Basic type comparison logic (`matches?` method)
+- ✅ Metrics: `count_leaf` (always 1) and `count_matches` (1 if matches?, else 0)
+- ✅ `matches?` comparison:
   - ClassInstance exact match
   - untyped (Bases::Any) matches everything
-  - Nil type comparison
-  - nil actual returns false (missing type)
-- ✅ Metrics: `count_leaf` (always 1) and `count_matches` (1 if matches?, else 0)
-- ❌ **Missing**: Union type handling
+  - top (Bases::Top) expected matches everything
+  - bottom (Bases::Bottom) actual matches everything
+  - Nil, Bool, Void, Self, Top, Bottom base types
+  - Union (order-independent)
+  - Optional (T? treated as T | nil)
+  - Tuple (element-wise)
+  - Intersection
+  - Block
+- ✅ `type_to_string` for all above types
 - ❌ **Missing**: Intersection type handling
 - ❌ **Missing**: Optional type handling (`Integer?`)
 - ❌ **Missing**: Tuple type handling

--- a/.claude/docs/rbs-specification.md
+++ b/.claude/docs/rbs-specification.md
@@ -1,0 +1,411 @@
+# RBS Specification Overview
+
+This document provides an overview of RBS (Ruby Signature) syntax that TypeEvalRb needs to support.
+
+## Official Documentation Sources
+
+- [RBS Syntax Documentation](https://github.com/ruby/rbs/blob/master/docs/syntax.md)
+- [RBS By Example](https://github.com/ruby/rbs/blob/master/docs/rbs_by_example.md)
+- [Writing Signatures Best Practices](https://github.com/ruby/rbs/wiki/Writing-Signatures-Best-Practices)
+- [Main Repository](https://github.com/ruby/rbs)
+
+## Type Syntax
+
+### Basic Types
+
+#### Class Instances
+```rbs
+Integer
+::Integer
+String
+Hash[Symbol, String]
+```
+
+#### Interfaces
+```rbs
+_ToS
+_Each[String]
+::Enumerator::_Each[String]
+```
+
+#### Type Aliases
+```rbs
+name
+list[Integer]
+```
+
+#### Singletons
+```rbs
+singleton(String)  # The String class itself
+```
+
+#### Literals
+```rbs
+123          # Integer literal
+"hello"      # String literal
+:symbol      # Symbol literal
+true         # true literal
+false        # false literal
+```
+
+### Composite Types
+
+#### Union Types
+```rbs
+Integer | String
+Integer | String | nil
+```
+
+#### Intersection Types
+```rbs
+_Reader & _Writer
+```
+
+#### Optional Types
+```rbs
+Integer?           # Equivalent to: Integer | nil
+String?
+```
+
+#### Record Types
+```rbs
+{ id: Integer, name: String }
+{ name: String, age: Integer? }
+```
+
+#### Tuple Types
+```rbs
+[]                     # Empty tuple
+[String]               # Single element
+[Integer, Integer]     # Pair
+[String, Integer, bool]
+```
+
+### Special Types
+
+#### Type System Types
+```rbs
+self          # Type of the receiver
+instance      # Instance of the class
+class         # The class itself
+```
+
+#### Boolean Type
+```rbs
+bool          # Alias for: true | false
+```
+
+#### Universal Types
+```rbs
+untyped       # Both subtype and supertype of all types
+top           # Supertype of all types
+bot           # Subtype of all types
+```
+
+#### Other Special Types
+```rbs
+nil           # nil type
+void          # Return type for methods with no meaningful return value
+```
+
+### Proc Types
+
+```rbs
+^(Integer) -> String
+^(?String, size: Integer) -> bool
+^(Integer) [self: String] -> void     # With self-type binding
+```
+
+## Method Definitions
+
+### Instance Methods
+
+```rbs
+def to_s: () -> String
+def length: () -> Integer
+```
+
+### Singleton Methods
+
+```rbs
+def self.new: () -> Object
+def self.create: (String) -> instance
+```
+
+### Module Functions
+
+```rbs
+def self?.sqrt: (Numeric) -> Numeric
+```
+
+### Method Overloading
+
+```rbs
+def +: (Float) -> Float
+     | (Integer) -> Integer
+     | (Numeric) -> Numeric
+```
+
+### Method Parameters
+
+#### Required Positional Parameters
+```rbs
+def foo: (Integer, String) -> void
+```
+
+#### Optional Positional Parameters
+```rbs
+def foo: (?Integer size) -> void
+def bar: (?Integer, ?String?) -> void
+```
+
+#### Rest Parameters
+```rbs
+def foo: (*Integer) -> void
+def bar: (String, *Integer) -> void
+```
+
+#### Keyword Parameters
+```rbs
+def foo: (name: String) -> void                    # Required keyword
+def bar: (?name: String) -> void                   # Optional keyword
+def baz: (size: Integer sz, ?name: String) -> void # With labels
+```
+
+#### Keyword Rest Parameters
+```rbs
+def foo: (**String) -> void
+```
+
+#### Block Parameters
+```rbs
+def each: () { (String) -> void } -> void
+def map: [U] () { (String) -> U } -> Array[U]
+```
+
+### Method Visibility
+
+```rbs
+private def puts: (*untyped) -> void
+public def self.puts: (*untyped) -> void
+protected def internal: () -> void
+```
+
+## Class/Module/Interface Declarations
+
+### Class Declarations
+
+#### Basic Class
+```rbs
+class Stack
+  def push: (String) -> void
+  def pop: () -> String
+end
+```
+
+#### Generic Class
+```rbs
+class Stack[T]
+  def push: (T) -> void
+  def pop: () -> T
+end
+```
+
+#### Inheritance
+```rbs
+class Child < Parent
+end
+
+class StringStack < Stack[String]
+end
+```
+
+### Module Declarations
+
+```rbs
+module Enumerable[A, B] : _Each[A, B]
+  def count: () -> Integer
+end
+```
+
+### Interface Declarations
+
+```rbs
+interface _Hashing
+  def hash: () -> Integer
+  def eql?: (untyped) -> bool
+end
+```
+
+### Aliases
+
+```rbs
+class Bar = Array
+module Foo = Kernel
+```
+
+## Class/Module Members
+
+### Instance Variables
+
+```rbs
+@name: String
+@value: Integer?
+self.@class_ivar: Hash[Symbol, String]  # Class instance variable
+```
+
+### Class Variables
+
+```rbs
+@@instances: Array[instance]
+```
+
+### Attributes
+
+```rbs
+attr_reader id: Integer
+attr_writer name: String
+attr_accessor email: String
+
+# With custom names
+attr_writer name (@raw_name): String
+
+# With method types
+attr_accessor people (): Array[Person]
+```
+
+### Mixins
+
+```rbs
+include Enumerable[String, void]
+extend ActiveSupport::Concern
+prepend Decorator
+```
+
+### Alias Methods
+
+```rbs
+alias collect map
+alias self.new self.create
+```
+
+### Constants
+
+```rbs
+VERSION: String
+DEFAULT_SIZE: Integer
+```
+
+## Generics & Type Parameters
+
+### Variance
+
+```rbs
+class Array[out T]                    # Covariant
+class Contravariant[in T]             # Contravariant
+class Invariant[T]                    # Invariant (default)
+class Array[unchecked out T]          # Skip variance validation
+```
+
+### Bounds
+
+```rbs
+class Box[T < Comparable]             # Upper bound
+class Container[T > Numeric]          # Lower bound
+class Flexible[T > Integer < Numeric] # Both bounds
+```
+
+### Default Type Parameters
+
+```rbs
+interface _Foo[T = untyped]
+class Container[T = String]
+```
+
+## Type Aliases
+
+```rbs
+type subject = Attendee | Speaker
+type list[out T] = [T, list[T]] | nil
+type json = Integer | String | bool | Hash[String, json] | Array[json]
+```
+
+## Constants & Global Variables
+
+```rbs
+Person::DefaultEmail: String
+SOME_CONSTANT: Integer
+
+$LOAD_PATH: Array[String]
+$stderr: IO
+```
+
+## Directives
+
+### Use Directive
+
+```rbs
+use RBS::Namespace
+use RBS::TypeName as TN
+use RBS::AST::*
+```
+
+## Annotations
+
+```rbs
+%a{ metadata }
+%a( metadata )
+%a[ metadata ]
+%a| metadata |
+%a< metadata >
+```
+
+## Visibility Defaults
+
+```rbs
+public
+
+def foo: () -> void
+def bar: () -> void
+
+private
+
+def baz: () -> void
+def qux: () -> void
+```
+
+## Implementation Considerations for TypeEvalRb
+
+### Phase 1: Basic Support
+- Class instances (with and without generics)
+- Instance methods with basic parameters
+- Instance variables
+- Basic types (Integer, String, etc.)
+
+### Phase 2: Type System
+- Union types
+- Optional types
+- Tuple types
+- Record types
+- Intersection types
+
+### Phase 3: Advanced Method Signatures
+- Optional parameters
+- Keyword parameters
+- Rest parameters
+- Block parameters
+- Method overloading
+
+### Phase 4: Advanced Class Features
+- Generic type parameters with variance
+- Type bounds
+- Module mixins
+- Attributes
+- Singleton methods
+
+### Phase 5: Additional Features
+- Interfaces
+- Type aliases
+- Constants and global variables
+- Proc types
+- Special types (self, instance, class, etc.)

--- a/.claude/docs/roadmap.md
+++ b/.claude/docs/roadmap.md
@@ -1,0 +1,777 @@
+# Development Roadmap
+
+This document outlines the development roadmap for TypeEvalRb.
+
+## Project Goals
+
+TypeEvalRb aims to be a comprehensive micro-benchmarking framework for Ruby type inference tools by:
+1. Supporting all RBS type signature features
+2. Providing accurate type comparison metrics
+3. Offering detailed mismatch analysis
+4. Supporting real-world benchmarking scenarios
+
+---
+
+## Detailed Task Checklist
+
+This checklist provides fine-grained, sequential tasks. Complete them in order from top to bottom.
+
+### Phase 1: Core Type Comparison (Priority: HIGH)
+
+**Goal**: Implement basic type comparison logic and metrics calculation.
+
+#### 1.1 TypeNode Comparison Logic (Basic Types)
+
+- [ ] 1.1.1: Add `matches?` method skeleton to TypeNode class (lib/type_eval_rb/comparison_tree/type_node.rb)
+- [ ] 1.1.2: Write unit test: TypeNode#matches? returns true for identical ClassInstance types
+- [ ] 1.1.3: Implement exact ClassInstance type matching in `matches?` method
+- [ ] 1.1.4: Write unit test: TypeNode#matches? returns true when actual is untyped
+- [ ] 1.1.5: Implement untyped handling (untyped matches everything) in `matches?`
+- [ ] 1.1.6: Write unit test: TypeNode#matches? returns true when expected is untyped
+- [ ] 1.1.7: Implement untyped handling for expected type in `matches?`
+- [ ] 1.1.8: Write unit test: TypeNode#matches? handles nil type correctly
+- [ ] 1.1.9: Implement nil type matching in `matches?`
+- [ ] 1.1.10: Write unit test: TypeNode#matches? returns false for mismatched types
+- [ ] 1.1.11: Verify mismatched type handling works correctly
+- [ ] 1.1.12: Write unit test: TypeNode#matches? handles nil actual gracefully
+- [ ] 1.1.13: Implement nil actual handling (treat as missing type, returns false)
+- [ ] 1.1.14: Update TypeNode#type_to_string to handle Bases::Nil type
+- [ ] 1.1.15: Update TypeNode#type_to_string to handle Bases::Any (untyped) type
+- [ ] 1.1.16: Run all TypeNode tests and verify they pass
+- [ ] 1.1.17: Update implementation-status.md to mark TypeNode basic comparison as implemented
+
+#### 1.2 TypeNode Metrics (Leaf Counting)
+
+- [ ] 1.2.1: Add `count_leaf` method skeleton to TypeNode class
+- [ ] 1.2.2: Write unit test: TypeNode#count_leaf returns 1 (TypeNode is always a leaf)
+- [ ] 1.2.3: Implement `count_leaf` to return 1
+- [ ] 1.2.4: Run TypeNode tests and verify they pass
+
+#### 1.3 TypeNode Metrics (Match Counting)
+
+- [ ] 1.3.1: Add `count_matches` method skeleton to TypeNode class
+- [ ] 1.3.2: Write unit test: TypeNode#count_matches returns 1 when types match
+- [ ] 1.3.3: Write unit test: TypeNode#count_matches returns 0 when types don't match
+- [ ] 1.3.4: Implement `count_matches` using `matches?` method
+- [ ] 1.3.5: Run TypeNode tests and verify they pass
+- [ ] 1.3.6: Update implementation-status.md to mark TypeNode metrics as implemented
+
+#### 1.4 ArgumentNode Metrics
+
+- [ ] 1.4.1: Add `count_leaf` method to ArgumentNode class
+- [ ] 1.4.2: Write unit test: ArgumentNode#count_leaf delegates to type.count_leaf
+- [ ] 1.4.3: Implement `count_leaf` to delegate to @type.count_leaf
+- [ ] 1.4.4: Add `count_matches` method to ArgumentNode class
+- [ ] 1.4.5: Write unit test: ArgumentNode#count_matches delegates to type.count_matches
+- [ ] 1.4.6: Implement `count_matches` to delegate to @type.count_matches
+- [ ] 1.4.7: Run ArgumentNode tests and verify they pass
+- [ ] 1.4.8: Update implementation-status.md to mark ArgumentNode metrics as implemented
+
+#### 1.5 InstanceVariableNode Metrics
+
+- [ ] 1.5.1: Add `count_leaf` method to InstanceVariableNode class
+- [ ] 1.5.2: Write unit test: InstanceVariableNode#count_leaf delegates to type.count_leaf
+- [ ] 1.5.3: Implement `count_leaf` to delegate to @type.count_leaf
+- [ ] 1.5.4: Add `count_matches` method to InstanceVariableNode class
+- [ ] 1.5.5: Write unit test: InstanceVariableNode#count_matches delegates to type.count_matches
+- [ ] 1.5.6: Implement `count_matches` to delegate to @type.count_matches
+- [ ] 1.5.7: Run InstanceVariableNode tests and verify they pass
+- [ ] 1.5.8: Update implementation-status.md to mark InstanceVariableNode metrics as implemented
+
+#### 1.6 MethodNode Metrics
+
+- [ ] 1.6.1: Add `count_leaf` method to MethodNode class
+- [ ] 1.6.2: Write unit test: MethodNode#count_leaf sums parameters and return_type leaf counts
+- [ ] 1.6.3: Implement `count_leaf` to sum @parameters.sum(&:count_leaf) + @return_type.count_leaf
+- [ ] 1.6.4: Add `count_matches` method to MethodNode class
+- [ ] 1.6.5: Write unit test: MethodNode#count_matches sums parameters and return_type match counts
+- [ ] 1.6.6: Implement `count_matches` to sum matches from parameters and return_type
+- [ ] 1.6.7: Run MethodNode tests and verify they pass
+- [ ] 1.6.8: Update implementation-status.md to mark MethodNode metrics as implemented
+
+#### 1.7 ClassNode Metrics
+
+- [ ] 1.7.1: Add `count_leaf` method to ClassNode class
+- [ ] 1.7.2: Write unit test: ClassNode#count_leaf sums instance_variables and methods leaf counts
+- [ ] 1.7.3: Implement `count_leaf` to sum from @instance_variable_nodes and @method_nodes
+- [ ] 1.7.4: Add `count_matches` method to ClassNode class
+- [ ] 1.7.5: Write unit test: ClassNode#count_matches sums instance_variables and methods match counts
+- [ ] 1.7.6: Implement `count_matches` to sum matches from instance_variables and methods
+- [ ] 1.7.7: Run ClassNode tests and verify they pass
+- [ ] 1.7.8: Update implementation-status.md to mark ClassNode metrics as implemented
+
+#### 1.8 ComparisonTree Metrics Aggregation
+
+- [ ] 1.8.1: Add `count_leaf` method to ComparisonTree class
+- [ ] 1.8.2: Write unit test: ComparisonTree#count_leaf sums all class_nodes leaf counts
+- [ ] 1.8.3: Implement `count_leaf` to sum @class_nodes.sum(&:count_leaf)
+- [ ] 1.8.4: Add `count_matches` method to ComparisonTree class
+- [ ] 1.8.5: Write unit test: ComparisonTree#count_matches sums all class_nodes match counts
+- [ ] 1.8.6: Implement `count_matches` to sum @class_nodes.sum(&:count_matches)
+- [ ] 1.8.7: Add `accuracy` method to ComparisonTree class
+- [ ] 1.8.8: Write unit test: ComparisonTree#accuracy returns count_matches / count_leaf as Float
+- [ ] 1.8.9: Implement `accuracy` to calculate and return accuracy percentage
+- [ ] 1.8.10: Write unit test: ComparisonTree#accuracy handles zero leaves gracefully
+- [ ] 1.8.11: Update `accuracy` to return 0.0 when count_leaf is 0
+- [ ] 1.8.12: Run ComparisonTree tests and verify they pass
+- [ ] 1.8.13: Update implementation-status.md to mark tree-level metrics as implemented
+
+#### 1.9 Integration Test for Phase 1
+
+- [ ] 1.9.1: Create integration test file: spec/integration/simple_comparison_spec.rb
+- [ ] 1.9.2: Write integration test: Load user_factory fixture and build comparison tree
+- [ ] 1.9.3: Write integration test: Verify tree structure is correct
+- [ ] 1.9.4: Write integration test: Calculate and verify metrics (count_leaf, count_matches, accuracy)
+- [ ] 1.9.5: Run integration tests and verify they pass
+- [ ] 1.9.6: Update CLAUDE.md to mention integration tests
+- [ ] 1.9.7: Update implementation-status.md to mark Phase 1 as complete
+
+---
+
+### Phase 2: Method Signature Support (Priority: HIGH)
+
+**Goal**: Support comprehensive method signature comparison.
+
+#### 2.1 Optional Positional Parameters
+
+- [ ] 2.1.1: Add `required` attribute (boolean) to ArgumentNode class
+- [ ] 2.1.2: Update ArgumentNode#initialize to accept `required:` parameter (default: true)
+- [ ] 2.1.3: Update ArgumentNode unit test to verify required attribute
+- [ ] 2.1.4: Update ArgumentNode#pretty_print to show required/optional status
+- [ ] 2.1.5: Update MethodNode.from_ast to detect optional parameters from RBS AST
+- [ ] 2.1.6: Write unit test: MethodNode.from_ast handles optional_positionals correctly
+- [ ] 2.1.7: Implement optional parameter parsing in MethodNode.from_ast
+- [ ] 2.1.8: Create fixture: spec/fixtures/examples/optional_params/
+- [ ] 2.1.9: Add Ruby code with optional parameters to fixture
+- [ ] 2.1.10: Add expected RBS with optional parameters to fixture
+- [ ] 2.1.11: Write integration test for optional parameters using new fixture
+- [ ] 2.1.12: Run tests and verify they pass
+- [ ] 2.1.13: Update implementation-status.md to mark optional parameters as implemented
+
+#### 2.2 Keyword Parameters (Required)
+
+- [ ] 2.2.1: Add `param_type` attribute (enum: :positional, :keyword) to ArgumentNode class
+- [ ] 2.2.2: Update ArgumentNode#initialize to accept `param_type:` parameter (default: :positional)
+- [ ] 2.2.3: Update ArgumentNode unit test to verify param_type attribute
+- [ ] 2.2.4: Update ArgumentNode#pretty_print to show parameter type
+- [ ] 2.2.5: Update MethodNode.from_ast to parse required keywords from RBS AST
+- [ ] 2.2.6: Write unit test: MethodNode.from_ast handles required_keywords correctly
+- [ ] 2.2.7: Implement required keyword parameter parsing in MethodNode.from_ast
+- [ ] 2.2.8: Run tests and verify they pass
+
+#### 2.3 Keyword Parameters (Optional)
+
+- [ ] 2.3.1: Update MethodNode.from_ast to parse optional keywords from RBS AST
+- [ ] 2.3.2: Write unit test: MethodNode.from_ast handles optional_keywords correctly
+- [ ] 2.3.3: Implement optional keyword parameter parsing in MethodNode.from_ast
+- [ ] 2.3.4: Create fixture: spec/fixtures/examples/keyword_params/
+- [ ] 2.3.5: Add Ruby code with required and optional keyword parameters to fixture
+- [ ] 2.3.6: Add expected RBS with keyword parameters to fixture
+- [ ] 2.3.7: Write integration test for keyword parameters using new fixture
+- [ ] 2.3.8: Run tests and verify they pass
+- [ ] 2.3.9: Update implementation-status.md to mark keyword parameters as implemented
+
+#### 2.4 Rest Parameters (Positional)
+
+- [ ] 2.4.1: Add `rest` attribute (boolean) to ArgumentNode class
+- [ ] 2.4.2: Update ArgumentNode#initialize to accept `rest:` parameter (default: false)
+- [ ] 2.4.3: Update ArgumentNode unit test to verify rest attribute
+- [ ] 2.4.4: Update ArgumentNode#pretty_print to show rest parameter indicator
+- [ ] 2.4.5: Update MethodNode.from_ast to parse rest_positionals from RBS AST
+- [ ] 2.4.6: Write unit test: MethodNode.from_ast handles rest_positionals correctly
+- [ ] 2.4.7: Implement rest positional parameter parsing in MethodNode.from_ast
+- [ ] 2.4.8: Run tests and verify they pass
+
+#### 2.5 Rest Parameters (Keyword)
+
+- [ ] 2.5.1: Update MethodNode.from_ast to parse rest_keywords from RBS AST
+- [ ] 2.5.2: Write unit test: MethodNode.from_ast handles rest_keywords correctly
+- [ ] 2.5.3: Implement keyword rest parameter parsing in MethodNode.from_ast
+- [ ] 2.5.4: Create fixture: spec/fixtures/examples/rest_params/
+- [ ] 2.5.5: Add Ruby code with rest parameters to fixture
+- [ ] 2.5.6: Add expected RBS with rest parameters to fixture
+- [ ] 2.5.7: Write integration test for rest parameters using new fixture
+- [ ] 2.5.8: Run tests and verify they pass
+- [ ] 2.5.9: Update implementation-status.md to mark rest parameters as implemented
+
+#### 2.6 Block Parameters
+
+- [ ] 2.6.1: Add `block` attribute (TypeNode or nil) to MethodNode class
+- [ ] 2.6.2: Update MethodNode#initialize to accept `block:` parameter (default: nil)
+- [ ] 2.6.3: Update MethodNode unit test to verify block attribute
+- [ ] 2.6.4: Update MethodNode#pretty_print to show block parameter
+- [ ] 2.6.5: Update MethodNode#count_leaf to include block leaf count if present
+- [ ] 2.6.6: Update MethodNode#count_matches to include block match count if present
+- [ ] 2.6.7: Update MethodNode.from_ast to parse block from RBS AST
+- [ ] 2.6.8: Write unit test: MethodNode.from_ast handles block parameter correctly
+- [ ] 2.6.9: Implement block parameter parsing in MethodNode.from_ast
+- [ ] 2.6.10: Create fixture: spec/fixtures/examples/block_params/
+- [ ] 2.6.11: Add Ruby code with block parameters to fixture
+- [ ] 2.6.12: Add expected RBS with block parameters to fixture
+- [ ] 2.6.13: Write integration test for block parameters using new fixture
+- [ ] 2.6.14: Run tests and verify they pass
+- [ ] 2.6.15: Update implementation-status.md to mark block parameters as implemented
+
+#### 2.7 Singleton Methods
+
+- [ ] 2.7.1: Add `kind` attribute (enum: :instance, :singleton) to MethodNode class
+- [ ] 2.7.2: Update MethodNode#initialize to accept `kind:` parameter (default: :instance)
+- [ ] 2.7.3: Update MethodNode unit test to verify kind attribute
+- [ ] 2.7.4: Update MethodNode#pretty_print to show method kind
+- [ ] 2.7.5: Update MethodNode.from_ast to detect singleton methods from RBS AST
+- [ ] 2.7.6: Write unit test: MethodNode.from_ast handles singleton methods correctly
+- [ ] 2.7.7: Implement singleton method detection in MethodNode.from_ast
+- [ ] 2.7.8: Update ClassNode.methods_to_nodes to handle both instance and singleton methods
+- [ ] 2.7.9: Create fixture: spec/fixtures/examples/singleton_methods/
+- [ ] 2.7.10: Add Ruby code with singleton methods to fixture
+- [ ] 2.7.11: Add expected RBS with singleton methods to fixture
+- [ ] 2.7.12: Write integration test for singleton methods using new fixture
+- [ ] 2.7.13: Run tests and verify they pass
+- [ ] 2.7.14: Update implementation-status.md to mark singleton methods as implemented
+- [ ] 2.7.15: Update implementation-status.md to mark Phase 2 as complete
+
+---
+
+### Phase 3: Type System Coverage (Priority: MEDIUM)
+
+**Goal**: Support RBS composite and special types.
+
+#### 3.1 Union Types (Parsing)
+
+- [ ] 3.1.1: Research RBS::Types::Union structure in RBS gem
+- [ ] 3.1.2: Update TypeNode#type_to_string to handle Union types
+- [ ] 3.1.3: Write unit test: TypeNode#type_to_string formats union types correctly
+- [ ] 3.1.4: Implement union type formatting in type_to_string
+- [ ] 3.1.5: Run tests and verify they pass
+
+#### 3.2 Union Types (Comparison)
+
+- [ ] 3.2.1: Write unit test: TypeNode#matches? handles exact union match (same types, same order)
+- [ ] 3.2.2: Implement basic union comparison in matches? method
+- [ ] 3.2.3: Write unit test: TypeNode#matches? handles union match (same types, different order)
+- [ ] 3.2.4: Implement order-independent union comparison
+- [ ] 3.2.5: Write unit test: TypeNode#matches? handles subset union (actual is more specific)
+- [ ] 3.2.6: Implement subset union comparison
+- [ ] 3.2.7: Write unit test: TypeNode#matches? handles simple type matching union
+- [ ] 3.2.8: Implement simple type matching against union
+- [ ] 3.2.9: Run tests and verify they pass
+
+#### 3.3 Union Types (Nested and Fixtures)
+
+- [ ] 3.3.1: Write unit test: TypeNode#matches? handles nested unions
+- [ ] 3.3.2: Implement nested union comparison
+- [ ] 3.3.3: Create fixture: spec/fixtures/examples/union_types/
+- [ ] 3.3.4: Add Ruby code with union types to fixture
+- [ ] 3.3.5: Add expected RBS with union types to fixture
+- [ ] 3.3.6: Write integration test for union types using new fixture
+- [ ] 3.3.7: Run tests and verify they pass
+- [ ] 3.3.8: Update implementation-status.md to mark union types as implemented
+
+#### 3.4 Optional Types
+
+- [ ] 3.4.1: Research RBS::Types::Optional structure in RBS gem
+- [ ] 3.4.2: Update TypeNode#type_to_string to handle Optional types
+- [ ] 3.4.3: Write unit test: TypeNode#type_to_string formats optional types correctly
+- [ ] 3.4.4: Implement optional type formatting
+- [ ] 3.4.5: Write unit test: TypeNode#matches? treats Optional[T] as T | nil
+- [ ] 3.4.6: Implement optional type normalization and comparison
+- [ ] 3.4.7: Create fixture: spec/fixtures/examples/optional_types/
+- [ ] 3.4.8: Add Ruby code with optional types to fixture
+- [ ] 3.4.9: Add expected RBS with optional types to fixture
+- [ ] 3.4.10: Write integration test for optional types using new fixture
+- [ ] 3.4.11: Run tests and verify they pass
+- [ ] 3.4.12: Update implementation-status.md to mark optional types as implemented
+
+#### 3.5 Tuple Types
+
+- [ ] 3.5.1: Research RBS::Types::Tuple structure in RBS gem
+- [ ] 3.5.2: Update TypeNode#type_to_string to handle Tuple types
+- [ ] 3.5.3: Write unit test: TypeNode#type_to_string formats tuple types correctly
+- [ ] 3.5.4: Implement tuple type formatting
+- [ ] 3.5.5: Write unit test: TypeNode#matches? compares tuples element-wise
+- [ ] 3.5.6: Implement tuple element-wise comparison
+- [ ] 3.5.7: Write unit test: TypeNode#matches? handles different length tuples
+- [ ] 3.5.8: Implement length checking for tuples
+- [ ] 3.5.9: Create fixture: spec/fixtures/examples/tuple_types/
+- [ ] 3.5.10: Add Ruby code with tuple types to fixture
+- [ ] 3.5.11: Add expected RBS with tuple types to fixture
+- [ ] 3.5.12: Write integration test for tuple types using new fixture
+- [ ] 3.5.13: Run tests and verify they pass
+- [ ] 3.5.14: Update implementation-status.md to mark tuple types as implemented
+
+#### 3.6 Record Types
+
+- [ ] 3.6.1: Research RBS::Types::Record structure in RBS gem
+- [ ] 3.6.2: Update TypeNode#type_to_string to handle Record types
+- [ ] 3.6.3: Write unit test: TypeNode#type_to_string formats record types correctly
+- [ ] 3.6.4: Implement record type formatting
+- [ ] 3.6.5: Write unit test: TypeNode#matches? compares records key-by-key
+- [ ] 3.6.6: Implement record key-value comparison
+- [ ] 3.6.7: Write unit test: TypeNode#matches? handles missing record keys
+- [ ] 3.6.8: Implement missing key handling for records
+- [ ] 3.6.9: Create fixture: spec/fixtures/examples/record_types/
+- [ ] 3.6.10: Add Ruby code with record types to fixture
+- [ ] 3.6.11: Add expected RBS with record types to fixture
+- [ ] 3.6.12: Write integration test for record types using new fixture
+- [ ] 3.6.13: Run tests and verify they pass
+- [ ] 3.6.14: Update implementation-status.md to mark record types as implemented
+
+#### 3.7 Intersection Types
+
+- [ ] 3.7.1: Research RBS::Types::Intersection structure in RBS gem
+- [ ] 3.7.2: Update TypeNode#type_to_string to handle Intersection types
+- [ ] 3.7.3: Write unit test: TypeNode#type_to_string formats intersection types correctly
+- [ ] 3.7.4: Implement intersection type formatting
+- [ ] 3.7.5: Write unit test: TypeNode#matches? compares intersection types
+- [ ] 3.7.6: Implement intersection type comparison (all components must match)
+- [ ] 3.7.7: Create fixture: spec/fixtures/examples/intersection_types/
+- [ ] 3.7.8: Add Ruby code with intersection types to fixture
+- [ ] 3.7.9: Add expected RBS with intersection types to fixture
+- [ ] 3.7.10: Write integration test for intersection types using new fixture
+- [ ] 3.7.11: Run tests and verify they pass
+- [ ] 3.7.12: Update implementation-status.md to mark intersection types as implemented
+
+#### 3.8 Special Types (bool, void)
+
+- [ ] 3.8.1: Research RBS special type structures (Bases::Bool, Bases::Void, etc.)
+- [ ] 3.8.2: Update TypeNode#type_to_string to handle bool type
+- [ ] 3.8.3: Update TypeNode#type_to_string to handle void type
+- [ ] 3.8.4: Write unit test: TypeNode#matches? handles bool type correctly
+- [ ] 3.8.5: Write unit test: TypeNode#matches? handles void type correctly
+- [ ] 3.8.6: Implement bool and void type comparison
+- [ ] 3.8.7: Run tests and verify they pass
+
+#### 3.9 Special Types (self, instance, class)
+
+- [ ] 3.9.1: Research RBS::Types::Bases::Self, Instance, Class structures
+- [ ] 3.9.2: Update TypeNode#type_to_string to handle self type
+- [ ] 3.9.3: Update TypeNode#type_to_string to handle instance type
+- [ ] 3.9.4: Update TypeNode#type_to_string to handle class type
+- [ ] 3.9.5: Write unit test: TypeNode#matches? handles self type correctly
+- [ ] 3.9.6: Write unit test: TypeNode#matches? handles instance type correctly
+- [ ] 3.9.7: Write unit test: TypeNode#matches? handles class type correctly
+- [ ] 3.9.8: Implement self, instance, class type comparison
+- [ ] 3.9.9: Run tests and verify they pass
+
+#### 3.10 Special Types (top, bot)
+
+- [ ] 3.10.1: Research RBS::Types::Bases::Top and Bot structures
+- [ ] 3.10.2: Update TypeNode#type_to_string to handle top type
+- [ ] 3.10.3: Update TypeNode#type_to_string to handle bot type
+- [ ] 3.10.4: Write unit test: TypeNode#matches? handles top type (supertype of all)
+- [ ] 3.10.5: Write unit test: TypeNode#matches? handles bot type (subtype of all)
+- [ ] 3.10.6: Implement top and bot type comparison
+- [ ] 3.10.7: Create fixture: spec/fixtures/examples/special_types/
+- [ ] 3.10.8: Add Ruby code with special types to fixture
+- [ ] 3.10.9: Add expected RBS with special types to fixture
+- [ ] 3.10.10: Write integration test for special types using new fixture
+- [ ] 3.10.11: Run tests and verify they pass
+- [ ] 3.10.12: Update implementation-status.md to mark special types as implemented
+- [ ] 3.10.13: Update implementation-status.md to mark Phase 3 as complete
+
+---
+
+### Phase 4: Generic Type Parameters (Priority: MEDIUM)
+
+**Goal**: Support generic types with parameters, variance, and bounds.
+
+#### 4.1 Basic Generics (Parsing)
+
+- [ ] 4.1.1: Add `type_params` attribute (Array) to ClassNode class
+- [ ] 4.1.2: Update ClassNode#initialize to accept `type_params:` parameter (default: [])
+- [ ] 4.1.3: Update ClassNode unit test to verify type_params attribute
+- [ ] 4.1.4: Update ClassNode.from_decls to extract type parameters from RBS declaration
+- [ ] 4.1.5: Write unit test: ClassNode.from_decls parses generic type parameters
+- [ ] 4.1.6: Implement type parameter extraction in ClassNode.from_decls
+- [ ] 4.1.7: Run tests and verify they pass
+
+#### 4.2 Basic Generics (Comparison)
+
+- [ ] 4.2.1: Update ClassNode#pretty_print to show type parameters
+- [ ] 4.2.2: Write unit test: ClassNode with matching type parameters
+- [ ] 4.2.3: Write unit test: ClassNode with mismatched type parameter count
+- [ ] 4.2.4: Create fixture: spec/fixtures/examples/generic_class/
+- [ ] 4.2.5: Add Ruby code with generic class to fixture
+- [ ] 4.2.6: Add expected RBS with generic class to fixture
+- [ ] 4.2.7: Write integration test for generic classes using new fixture
+- [ ] 4.2.8: Run tests and verify they pass
+- [ ] 4.2.9: Update implementation-status.md to mark basic generics as implemented
+
+#### 4.3 Generic Type Instantiation
+
+- [ ] 4.3.1: Research RBS::Types::ClassInstance with type arguments
+- [ ] 4.3.2: Update TypeNode#type_to_string to show type arguments for ClassInstance
+- [ ] 4.3.3: Write unit test: TypeNode#matches? compares generic instantiations
+- [ ] 4.3.4: Write unit test: Array[String] matches Array[String] but not Array[Integer]
+- [ ] 4.3.5: Implement generic type argument comparison in TypeNode#matches?
+- [ ] 4.3.6: Create fixture: spec/fixtures/examples/generic_instantiation/
+- [ ] 4.3.7: Add Ruby code using instantiated generics to fixture
+- [ ] 4.3.8: Add expected RBS with instantiated generics to fixture
+- [ ] 4.3.9: Write integration test for generic instantiation using new fixture
+- [ ] 4.3.10: Run tests and verify they pass
+- [ ] 4.3.11: Update implementation-status.md to mark generic instantiation as implemented
+
+#### 4.4 Type Parameter Variance
+
+- [ ] 4.4.1: Research RBS type parameter variance (covariant, contravariant, invariant)
+- [ ] 4.4.2: Store variance information in ClassNode type_params
+- [ ] 4.4.3: Write unit test: ClassNode stores variance for each type parameter
+- [ ] 4.4.4: Implement variance extraction in ClassNode.from_decls
+- [ ] 4.4.5: Update ClassNode#pretty_print to show variance
+- [ ] 4.4.6: Create fixture: spec/fixtures/examples/variance/
+- [ ] 4.4.7: Add Ruby code with covariant/contravariant types to fixture
+- [ ] 4.4.8: Add expected RBS with variance annotations to fixture
+- [ ] 4.4.9: Write integration test for variance using new fixture
+- [ ] 4.4.10: Run tests and verify they pass
+- [ ] 4.4.11: Update implementation-status.md to mark variance as implemented
+
+#### 4.5 Type Parameter Bounds
+
+- [ ] 4.5.1: Research RBS type parameter bounds (upper/lower)
+- [ ] 4.5.2: Store bound information in ClassNode type_params
+- [ ] 4.5.3: Write unit test: ClassNode stores bounds for type parameters
+- [ ] 4.5.4: Implement bounds extraction in ClassNode.from_decls
+- [ ] 4.5.5: Update ClassNode#pretty_print to show bounds
+- [ ] 4.5.6: Create fixture: spec/fixtures/examples/type_bounds/
+- [ ] 4.5.7: Add Ruby code with bounded type parameters to fixture
+- [ ] 4.5.8: Add expected RBS with type bounds to fixture
+- [ ] 4.5.9: Write integration test for type bounds using new fixture
+- [ ] 4.5.10: Run tests and verify they pass
+- [ ] 4.5.11: Update implementation-status.md to mark type bounds as implemented
+- [ ] 4.5.12: Update implementation-status.md to mark Phase 4 as complete
+
+---
+
+### Phase 5: Class/Module Features (Priority: MEDIUM)
+
+**Goal**: Support inheritance, mixins, and other class-level features.
+
+#### 5.1 Inheritance (Parsing)
+
+- [ ] 5.1.1: Add `super_class` attribute to ClassNode class
+- [ ] 5.1.2: Update ClassNode#initialize to accept `super_class:` parameter (default: nil)
+- [ ] 5.1.3: Update ClassNode unit test to verify super_class attribute
+- [ ] 5.1.4: Update ClassNode.from_decls to extract parent class from RBS declaration
+- [ ] 5.1.5: Write unit test: ClassNode.from_decls parses inheritance relationship
+- [ ] 5.1.6: Implement parent class extraction in ClassNode.from_decls
+- [ ] 5.1.7: Run tests and verify they pass
+
+#### 5.2 Inheritance (Comparison and Fixtures)
+
+- [ ] 5.2.1: Update ClassNode#pretty_print to show parent class
+- [ ] 5.2.2: Write unit test: ClassNode with matching parent class
+- [ ] 5.2.3: Write unit test: ClassNode with mismatched parent class
+- [ ] 5.2.4: Update bird fixture to test inheritance comparison
+- [ ] 5.2.5: Write integration test for inheritance using bird fixture
+- [ ] 5.2.6: Run tests and verify they pass
+- [ ] 5.2.7: Update implementation-status.md to mark inheritance as implemented
+
+#### 5.3 Module Mixins (include)
+
+- [ ] 5.3.1: Add `includes` attribute (Array) to ClassNode class
+- [ ] 5.3.2: Update ClassNode#initialize to accept `includes:` parameter (default: [])
+- [ ] 5.3.3: Update ClassNode unit test to verify includes attribute
+- [ ] 5.3.4: Update ClassNode.from_decls to extract included modules from RBS
+- [ ] 5.3.5: Write unit test: ClassNode.from_decls parses include statements
+- [ ] 5.3.6: Implement include extraction in ClassNode.from_decls
+- [ ] 5.3.7: Run tests and verify they pass
+
+#### 5.4 Module Mixins (extend, prepend)
+
+- [ ] 5.4.1: Add `extends` and `prepends` attributes (Arrays) to ClassNode class
+- [ ] 5.4.2: Update ClassNode#initialize to accept `extends:` and `prepends:` parameters
+- [ ] 5.4.3: Update ClassNode unit test to verify extends and prepends attributes
+- [ ] 5.4.4: Update ClassNode.from_decls to extract extend and prepend statements
+- [ ] 5.4.5: Write unit test: ClassNode.from_decls parses extend and prepend statements
+- [ ] 5.4.6: Implement extend and prepend extraction
+- [ ] 5.4.7: Update ClassNode#pretty_print to show mixins
+- [ ] 5.4.8: Create fixture: spec/fixtures/examples/module_inclusion/
+- [ ] 5.4.9: Add Ruby code with module mixins to fixture
+- [ ] 5.4.10: Add expected RBS with include/extend/prepend to fixture
+- [ ] 5.4.11: Write integration test for module mixins using new fixture
+- [ ] 5.4.12: Run tests and verify they pass
+- [ ] 5.4.13: Update implementation-status.md to mark module mixins as implemented
+
+#### 5.5 Attributes (attr_reader)
+
+- [ ] 5.5.1: Research RBS::AST::Members::AttrReader structure
+- [ ] 5.5.2: Update ClassNode.from_decls to detect attr_reader members
+- [ ] 5.5.3: Convert attr_reader to equivalent getter MethodNode
+- [ ] 5.5.4: Write unit test: ClassNode.from_decls converts attr_reader to method
+- [ ] 5.5.5: Implement attr_reader conversion
+- [ ] 5.5.6: Run tests and verify they pass
+
+#### 5.6 Attributes (attr_writer, attr_accessor)
+
+- [ ] 5.6.1: Research RBS::AST::Members::AttrWriter and AttrAccessor structures
+- [ ] 5.6.2: Update ClassNode.from_decls to detect attr_writer and attr_accessor
+- [ ] 5.6.3: Convert attr_writer to equivalent setter MethodNode
+- [ ] 5.6.4: Convert attr_accessor to getter and setter MethodNodes
+- [ ] 5.6.5: Write unit test: ClassNode.from_decls converts attr_writer correctly
+- [ ] 5.6.6: Write unit test: ClassNode.from_decls converts attr_accessor correctly
+- [ ] 5.6.7: Implement attr_writer and attr_accessor conversion
+- [ ] 5.6.8: Create fixture: spec/fixtures/examples/attributes/
+- [ ] 5.6.9: Add Ruby code with attributes to fixture
+- [ ] 5.6.10: Add expected RBS with attr_reader/writer/accessor to fixture
+- [ ] 5.6.11: Write integration test for attributes using new fixture
+- [ ] 5.6.12: Run tests and verify they pass
+- [ ] 5.6.13: Update implementation-status.md to mark attributes as implemented
+
+#### 5.7 Class Instance Variables
+
+- [ ] 5.7.1: Update InstanceVariableNode to add `scope` attribute (:instance or :class)
+- [ ] 5.7.2: Update InstanceVariableNode#initialize to accept `scope:` parameter
+- [ ] 5.7.3: Update InstanceVariableNode unit test to verify scope attribute
+- [ ] 5.7.4: Update InstanceVariableNode.from_ast to detect self.@var syntax
+- [ ] 5.7.5: Write unit test: InstanceVariableNode.from_ast handles class instance variables
+- [ ] 5.7.6: Implement class instance variable detection
+- [ ] 5.7.7: Update InstanceVariableNode#pretty_print to show scope
+- [ ] 5.7.8: Create fixture: spec/fixtures/examples/class_instance_vars/
+- [ ] 5.7.9: Add Ruby code with class instance variables to fixture
+- [ ] 5.7.10: Add expected RBS with self.@var syntax to fixture
+- [ ] 5.7.11: Write integration test for class instance variables using new fixture
+- [ ] 5.7.12: Run tests and verify they pass
+- [ ] 5.7.13: Update implementation-status.md to mark class instance variables as implemented
+
+#### 5.8 Class Variables
+
+- [ ] 5.8.1: Create ClassVariableNode class (similar to InstanceVariableNode)
+- [ ] 5.8.2: Add ClassVariableNode#initialize with name and type
+- [ ] 5.8.3: Add ClassVariableNode#count_leaf and #count_matches methods
+- [ ] 5.8.4: Add ClassVariableNode#pretty_print method
+- [ ] 5.8.5: Write unit tests for ClassVariableNode
+- [ ] 5.8.6: Add `class_variable_nodes` attribute to ClassNode
+- [ ] 5.8.7: Update ClassNode#initialize to accept class_variable_nodes parameter
+- [ ] 5.8.8: Update ClassNode.from_decls to extract class variables
+- [ ] 5.8.9: Write unit test: ClassNode.from_decls parses class variables
+- [ ] 5.8.10: Implement class variable extraction
+- [ ] 5.8.11: Update ClassNode#count_leaf to include class variables
+- [ ] 5.8.12: Update ClassNode#count_matches to include class variables
+- [ ] 5.8.13: Update ClassNode#pretty_print to show class variables
+- [ ] 5.8.14: Create fixture: spec/fixtures/examples/class_variables/
+- [ ] 5.8.15: Add Ruby code with class variables to fixture
+- [ ] 5.8.16: Add expected RBS with @@var syntax to fixture
+- [ ] 5.8.17: Write integration test for class variables using new fixture
+- [ ] 5.8.18: Run tests and verify they pass
+- [ ] 5.8.19: Update implementation-status.md to mark class variables as implemented
+- [ ] 5.8.20: Update implementation-status.md to mark Phase 5 as complete
+
+---
+
+### Phase 6: Advanced RBS Features (Priority: LOW)
+
+**Goal**: Support remaining RBS features for completeness.
+
+#### 6.1 Interfaces (Parsing)
+
+- [ ] 6.1.1: Create InterfaceNode class (similar to ClassNode)
+- [ ] 6.1.2: Add InterfaceNode#initialize with typename and method_nodes
+- [ ] 6.1.3: Add InterfaceNode#count_leaf and #count_matches methods
+- [ ] 6.1.4: Add InterfaceNode#pretty_print method
+- [ ] 6.1.5: Write unit tests for InterfaceNode
+- [ ] 6.1.6: Update Environment.from_path to load interface declarations
+- [ ] 6.1.7: Write unit test: Environment.from_path loads interfaces
+- [ ] 6.1.8: Implement interface loading in Environment
+- [ ] 6.1.9: Run tests and verify they pass
+
+#### 6.2 Interfaces (Comparison and Fixtures)
+
+- [ ] 6.2.1: Update ComparisonTree.from_envs to handle interfaces
+- [ ] 6.2.2: Add `interface_nodes` attribute to ComparisonTree
+- [ ] 6.2.3: Update ComparisonTree#count_leaf to include interfaces
+- [ ] 6.2.4: Update ComparisonTree#count_matches to include interfaces
+- [ ] 6.2.5: Update ComparisonTree#pretty_print to show interfaces
+- [ ] 6.2.6: Create fixture: spec/fixtures/examples/interfaces/
+- [ ] 6.2.7: Add Ruby code implementing interfaces to fixture
+- [ ] 6.2.8: Add expected RBS with interface definitions to fixture
+- [ ] 6.2.9: Write integration test for interfaces using new fixture
+- [ ] 6.2.10: Run tests and verify they pass
+- [ ] 6.2.11: Update implementation-status.md to mark interfaces as implemented
+
+#### 6.3 Type Aliases (Loading)
+
+- [ ] 6.3.1: Update Environment.from_path to load type alias declarations
+- [ ] 6.3.2: Add `type_aliases` attribute to Environment class
+- [ ] 6.3.3: Write unit test: Environment.from_path loads type aliases
+- [ ] 6.3.4: Implement type alias loading
+- [ ] 6.3.5: Run tests and verify they pass
+
+#### 6.4 Type Aliases (Resolution)
+
+- [ ] 6.4.1: Add type alias resolution method to Environment class
+- [ ] 6.4.2: Write unit test: Type aliases are resolved during comparison
+- [ ] 6.4.3: Update TypeNode#matches? to resolve type aliases before comparison
+- [ ] 6.4.4: Handle recursive type aliases with cycle detection
+- [ ] 6.4.5: Write unit test: Recursive type aliases are handled correctly
+- [ ] 6.4.6: Create fixture: spec/fixtures/examples/type_aliases/
+- [ ] 6.4.7: Add Ruby code using type aliases to fixture
+- [ ] 6.4.8: Add expected RBS with type alias definitions to fixture
+- [ ] 6.4.9: Write integration test for type aliases using new fixture
+- [ ] 6.4.10: Run tests and verify they pass
+- [ ] 6.4.11: Update implementation-status.md to mark type aliases as implemented
+
+#### 6.5 Method Overloading
+
+- [ ] 6.5.1: Update MethodNode to store multiple overloads (Array of signatures)
+- [ ] 6.5.2: Update MethodNode#initialize to accept overloads parameter
+- [ ] 6.5.3: Update MethodNode.from_ast to extract all method overloads
+- [ ] 6.5.4: Write unit test: MethodNode.from_ast handles method overloading
+- [ ] 6.5.5: Implement overload extraction
+- [ ] 6.5.6: Update MethodNode#count_leaf to sum across all overloads
+- [ ] 6.5.7: Update MethodNode#count_matches to handle overload matching
+- [ ] 6.5.8: Implement overload matching logic (best match or all matches)
+- [ ] 6.5.9: Update MethodNode#pretty_print to show all overloads
+- [ ] 6.5.10: Create fixture: spec/fixtures/examples/method_overloading/
+- [ ] 6.5.11: Add Ruby code with overloaded methods to fixture
+- [ ] 6.5.12: Add expected RBS with method overloads to fixture
+- [ ] 6.5.13: Write integration test for method overloading using new fixture
+- [ ] 6.5.14: Run tests and verify they pass
+- [ ] 6.5.15: Update implementation-status.md to mark method overloading as implemented
+
+#### 6.6 Proc Types
+
+- [ ] 6.6.1: Research RBS::Types::Proc structure
+- [ ] 6.6.2: Update TypeNode#type_to_string to handle Proc types
+- [ ] 6.6.3: Write unit test: TypeNode#type_to_string formats proc types correctly
+- [ ] 6.6.4: Implement proc type formatting
+- [ ] 6.6.5: Write unit test: TypeNode#matches? compares proc signatures
+- [ ] 6.6.6: Implement proc type comparison (parameters and return type)
+- [ ] 6.6.7: Write unit test: TypeNode#matches? handles self-type binding in procs
+- [ ] 6.6.8: Implement self-type binding comparison
+- [ ] 6.6.9: Create fixture: spec/fixtures/examples/proc_types/
+- [ ] 6.6.10: Add Ruby code with proc types to fixture
+- [ ] 6.6.11: Add expected RBS with proc signatures to fixture
+- [ ] 6.6.12: Write integration test for proc types using new fixture
+- [ ] 6.6.13: Run tests and verify they pass
+- [ ] 6.6.14: Update implementation-status.md to mark proc types as implemented
+
+#### 6.7 Constants
+
+- [ ] 6.7.1: Create ConstantNode class
+- [ ] 6.7.2: Add ConstantNode#initialize with name and type
+- [ ] 6.7.3: Add ConstantNode#count_leaf and #count_matches methods
+- [ ] 6.7.4: Add ConstantNode#pretty_print method
+- [ ] 6.7.5: Write unit tests for ConstantNode
+- [ ] 6.7.6: Add `constant_nodes` attribute to ClassNode
+- [ ] 6.7.7: Update ClassNode.from_decls to extract constants
+- [ ] 6.7.8: Write unit test: ClassNode.from_decls parses constants
+- [ ] 6.7.9: Implement constant extraction
+- [ ] 6.7.10: Update ClassNode#count_leaf to include constants
+- [ ] 6.7.11: Update ClassNode#count_matches to include constants
+- [ ] 6.7.12: Update ClassNode#pretty_print to show constants
+- [ ] 6.7.13: Run tests and verify they pass
+
+#### 6.8 Global Variables
+
+- [ ] 6.8.1: Create GlobalVariableNode class
+- [ ] 6.8.2: Add GlobalVariableNode#initialize with name and type
+- [ ] 6.8.3: Add GlobalVariableNode#count_leaf and #count_matches methods
+- [ ] 6.8.4: Add GlobalVariableNode#pretty_print method
+- [ ] 6.8.5: Write unit tests for GlobalVariableNode
+- [ ] 6.8.6: Update Environment.from_path to load global variable declarations
+- [ ] 6.8.7: Add `global_variable_nodes` attribute to ComparisonTree
+- [ ] 6.8.8: Update ComparisonTree.from_envs to compare global variables
+- [ ] 6.8.9: Update ComparisonTree#count_leaf to include global variables
+- [ ] 6.8.10: Update ComparisonTree#count_matches to include global variables
+- [ ] 6.8.11: Create fixture: spec/fixtures/examples/constants/
+- [ ] 6.8.12: Add Ruby code with constants and globals to fixture
+- [ ] 6.8.13: Add expected RBS with constant and global definitions to fixture
+- [ ] 6.8.14: Write integration test for constants/globals using new fixture
+- [ ] 6.8.15: Run tests and verify they pass
+- [ ] 6.8.16: Update implementation-status.md to mark constants and globals as implemented
+
+#### 6.9 Visibility Modifiers
+
+- [ ] 6.9.1: Add `visibility` attribute to MethodNode (:public, :private, :protected)
+- [ ] 6.9.2: Update MethodNode#initialize to accept visibility parameter (default: :public)
+- [ ] 6.9.3: Update MethodNode unit test to verify visibility attribute
+- [ ] 6.9.4: Update MethodNode.from_ast to extract visibility from RBS
+- [ ] 6.9.5: Write unit test: MethodNode.from_ast detects visibility modifiers
+- [ ] 6.9.6: Implement visibility extraction
+- [ ] 6.9.7: Update MethodNode#pretty_print to show visibility
+- [ ] 6.9.8: Create fixture: spec/fixtures/examples/visibility/
+- [ ] 6.9.9: Add Ruby code with visibility modifiers to fixture
+- [ ] 6.9.10: Add expected RBS with visibility modifiers to fixture
+- [ ] 6.9.11: Write integration test for visibility using new fixture
+- [ ] 6.9.12: Run tests and verify they pass
+- [ ] 6.9.13: Update implementation-status.md to mark visibility as implemented
+- [ ] 6.9.14: Update implementation-status.md to mark Phase 6 as complete
+
+---
+
+### Phase 7: Real-World Benchmarking (Priority: LOW)
+
+**Goal**: Support benchmarking with real-world codebases.
+
+#### 7.1 Reporting Infrastructure
+
+- [ ] 7.1.1: Create Reporter class in lib/type_eval_rb/reporter.rb
+- [ ] 7.1.2: Add Reporter#initialize accepting ComparisonTree
+- [ ] 7.1.3: Add Reporter#summary method to output basic statistics
+- [ ] 7.1.4: Write unit test: Reporter#summary shows count_leaf, count_matches, accuracy
+- [ ] 7.1.5: Implement summary reporting
+- [ ] 7.1.6: Add Reporter#detailed_mismatches method
+- [ ] 7.1.7: Write unit test: Reporter#detailed_mismatches lists all type mismatches
+- [ ] 7.1.8: Implement detailed mismatch reporting
+- [ ] 7.1.9: Run tests and verify they pass
+
+#### 7.2 JSON Output Format
+
+- [ ] 7.2.1: Add Reporter#to_json method
+- [ ] 7.2.2: Write unit test: Reporter#to_json outputs valid JSON with metrics
+- [ ] 7.2.3: Implement JSON serialization of comparison results
+- [ ] 7.2.4: Write unit test: Reporter#to_json includes mismatch details
+- [ ] 7.2.5: Add mismatch details to JSON output
+- [ ] 7.2.6: Run tests and verify they pass
+
+#### 7.3 Standard Library Fixtures (Array)
+
+- [ ] 7.3.1: Create fixture: spec/fixtures/stdlib/array/
+- [ ] 7.3.2: Extract subset of Array RBS signature from Ruby core
+- [ ] 7.3.3: Add expected Array signature to fixture
+- [ ] 7.3.4: Create sample actual (inferred) signature with intentional differences
+- [ ] 7.3.5: Write benchmark test for Array comparison
+- [ ] 7.3.6: Run test and document accuracy metrics
+
+#### 7.4 Standard Library Fixtures (Hash, String)
+
+- [ ] 7.4.1: Create fixture: spec/fixtures/stdlib/hash/
+- [ ] 7.4.2: Extract subset of Hash RBS signature
+- [ ] 7.4.3: Add expected and actual signatures to fixture
+- [ ] 7.4.4: Write benchmark test for Hash
+- [ ] 7.4.5: Create fixture: spec/fixtures/stdlib/string/
+- [ ] 7.4.6: Extract subset of String RBS signature
+- [ ] 7.4.7: Add expected and actual signatures to fixture
+- [ ] 7.4.8: Write benchmark test for String
+- [ ] 7.4.9: Run tests and document metrics
+
+#### 7.5 Benchmark Documentation
+
+- [ ] 7.5.1: Create doc file: docs/benchmarking-guide.md
+- [ ] 7.5.2: Document how to run benchmarks
+- [ ] 7.5.3: Document how to add new benchmark fixtures
+- [ ] 7.5.4: Document how to interpret results
+- [ ] 7.5.5: Add example benchmark results
+- [ ] 7.5.6: Update CLAUDE.md to reference benchmarking guide
+- [ ] 7.5.7: Update implementation-status.md to mark Phase 7 as complete
+
+---
+
+## Progress Tracking
+
+- **Current Phase**: Phase 1 (Core Type Comparison)
+- **Next Task**: 1.1.1 - Add `matches?` method skeleton to TypeNode class
+- **Completed Tasks**: 0 / 350+
+
+## Completion Checklist
+
+After completing all phases:
+
+- [ ] All unit tests passing
+- [ ] All integration tests passing
+- [ ] Test coverage >90%
+- [ ] All documentation updated
+- [ ] implementation-status.md reflects 100% completion
+- [ ] README updated with usage examples
+- [ ] CHANGELOG updated
+- [ ] Version bumped for release

--- a/.claude/docs/testing-strategy.md
+++ b/.claude/docs/testing-strategy.md
@@ -1,0 +1,392 @@
+# Testing Strategy
+
+This document outlines the testing strategy for TypeEvalRb.
+
+## Testing Layers
+
+### 1. Unit Tests
+
+Unit tests focus on individual components in isolation.
+
+#### ComparisonTree Nodes
+
+Each node type should have tests for:
+- **Initialization**: Verify all attributes are set correctly
+- **Pretty-print**: Ensure correct formatting for debugging
+- **Type comparison**: Test the comparison logic (to be implemented)
+- **Metrics calculation**: Test count_leaf and count_matches (to be implemented)
+
+Example test structure:
+```ruby
+RSpec.describe TypeEvalRb::ComparisonTree::TypeNode do
+  describe '#initialize' do
+    # Test attribute assignment
+  end
+
+  describe '#pretty_print' do
+    # Test output formatting
+  end
+
+  describe '#matches?' do
+    # Test type comparison logic (to be implemented)
+  end
+
+  describe '#count_leaf' do
+    # Test leaf counting (to be implemented)
+  end
+
+  describe '#count_matches' do
+    # Test match counting (to be implemented)
+  end
+end
+```
+
+#### Environment Loading
+
+Test RBS file loading and parsing:
+- Loading from valid paths
+- Filtering class declarations correctly
+- Error handling for invalid RBS files
+- Multiple file handling
+
+### 2. Integration Tests
+
+Integration tests verify that components work correctly together.
+
+#### Tree Construction
+
+Test `ComparisonTree.from_envs` with various RBS signatures:
+- Simple classes
+- Classes with methods
+- Classes with instance variables
+- Classes with both methods and instance variables
+- Multiple classes
+- Inheritance hierarchies
+- Generic classes
+
+#### End-to-End Comparison
+
+Test complete comparison workflows:
+1. Load expected RBS from fixtures
+2. Load actual RBS (or generate from test data)
+3. Build comparison tree
+4. Verify tree structure
+5. Calculate and verify metrics
+
+### 3. Fixture-Based Tests
+
+Use real-world examples to test comprehensive scenarios.
+
+#### Current Fixtures
+
+Located in `spec/fixtures/examples/`:
+
+1. **`test/`** - Basic class with simple method
+   - Purpose: Baseline functionality test
+   - Coverage: Class, method, basic types
+
+2. **`multi_file_test/`** - Multiple classes across files
+   - Purpose: Multi-file RBS loading
+   - Coverage: Multiple class declarations
+
+3. **`user_factory/`** - Factory pattern
+   - Purpose: Instance variables and builder pattern
+   - Coverage: Instance variables, method chaining
+
+4. **`fix_errors_user_factory/`** - Same as above with errors
+   - Purpose: Error case handling
+   - Coverage: Type mismatches
+
+5. **`with_errors/`** - Error scenarios
+   - Purpose: Error handling
+   - Coverage: Invalid or missing types
+
+6. **`bird/`** - Inheritance
+   - Purpose: Inheritance hierarchy comparison
+   - Coverage: Class inheritance, method override
+
+7. **`dynamic_definitions/`** - Dynamic methods
+   - Purpose: Dynamically defined methods
+   - Coverage: Meta-programming scenarios
+
+8. **`namespace/`** - Namespaces
+   - Purpose: Namespace handling
+   - Coverage: Module namespacing
+
+#### Needed Fixtures
+
+To comprehensively test RBS features, we need additional fixtures:
+
+##### Type System Fixtures
+
+1. **`union_types/`** - Union type handling
+   ```rbs
+   def process: (Integer | String) -> void
+   ```
+
+2. **`optional_types/`** - Optional types
+   ```rbs
+   @name: String?
+   def set_value: (?Integer) -> void
+   ```
+
+3. **`tuple_types/`** - Tuple types
+   ```rbs
+   def coordinates: () -> [Integer, Integer]
+   ```
+
+4. **`record_types/`** - Record types
+   ```rbs
+   def user_info: () -> { name: String, age: Integer }
+   ```
+
+5. **`intersection_types/`** - Intersection types
+   ```rbs
+   def reader_writer: (_Reader & _Writer) -> void
+   ```
+
+##### Method Signature Fixtures
+
+6. **`keyword_params/`** - Keyword parameters
+   ```rbs
+   def create: (name: String, ?age: Integer) -> User
+   ```
+
+7. **`rest_params/`** - Rest parameters
+   ```rbs
+   def sum: (*Integer) -> Integer
+   def merge: (**String) -> Hash[Symbol, String]
+   ```
+
+8. **`block_params/`** - Block parameters
+   ```rbs
+   def each: () { (String) -> void } -> void
+   ```
+
+9. **`method_overloading/`** - Method overloading
+   ```rbs
+   def add: (Integer) -> Integer
+          | (String) -> String
+   ```
+
+10. **`singleton_methods/`** - Class methods
+    ```rbs
+    def self.create: (String) -> instance
+    ```
+
+##### Generic Type Fixtures
+
+11. **`generic_class/`** - Generic class
+    ```rbs
+    class Container[T]
+      def get: () -> T
+      def set: (T) -> void
+    end
+    ```
+
+12. **`variance/`** - Variance in generics
+    ```rbs
+    class CovariantList[out T]
+    class ContravariantList[in T]
+    ```
+
+13. **`type_bounds/`** - Type parameter bounds
+    ```rbs
+    class Comparable[T < Numeric]
+    ```
+
+##### Module and Mixin Fixtures
+
+14. **`module_inclusion/`** - Module include
+    ```rbs
+    module Enumerable[T]
+      def each: () { (T) -> void } -> void
+    end
+
+    class MyList[T]
+      include Enumerable[T]
+    end
+    ```
+
+15. **`attributes/`** - Attributes
+    ```rbs
+    class User
+      attr_reader name: String
+      attr_writer age: Integer
+      attr_accessor email: String
+    end
+    ```
+
+##### Advanced Fixtures
+
+16. **`interfaces/`** - Interface definitions
+    ```rbs
+    interface _ToJson
+      def to_json: () -> String
+    end
+    ```
+
+17. **`type_aliases/`** - Type aliases
+    ```rbs
+    type user_id = Integer
+    type json = Integer | String | bool | Hash[String, json] | Array[json]
+    ```
+
+18. **`proc_types/`** - Proc types
+    ```rbs
+    def map: (^(String) -> Integer) -> Array[Integer]
+    ```
+
+19. **`visibility/`** - Method visibility
+    ```rbs
+    private def internal: () -> void
+    public def api: () -> String
+    ```
+
+20. **`constants/`** - Constants and globals
+    ```rbs
+    VERSION: String
+    $LOAD_PATH: Array[String]
+    ```
+
+### 4. Property-Based Tests (Future)
+
+For comprehensive coverage, consider property-based testing:
+- Generate random RBS signatures
+- Verify invariants (e.g., count_leaf >= count_matches)
+- Test comparison symmetry and transitivity
+
+## Test Organization
+
+```
+spec/
+├── type_eval_rb_spec.rb                    # Basic gem tests
+├── type_eval_rb/
+│   ├── environment_spec.rb                 # Environment loading tests
+│   └── comparison_tree/
+│       ├── type_node_spec.rb              # TypeNode unit tests
+│       ├── argument_node_spec.rb          # ArgumentNode unit tests
+│       ├── method_node_spec.rb            # MethodNode unit tests
+│       ├── instance_variable_node_spec.rb # InstanceVariableNode unit tests
+│       ├── class_node_spec.rb             # ClassNode unit tests
+│       └── integration_spec.rb            # Integration tests (to be added)
+├── fixtures/
+│   └── examples/                          # Example RBS fixtures
+│       ├── test/
+│       ├── user_factory/
+│       ├── bird/
+│       ├── union_types/                   # To be added
+│       ├── generic_class/                 # To be added
+│       └── ...                            # More fixtures to be added
+└── support/
+    ├── fixtures_helper.rb                 # Fixture loading helpers
+    ├── type_helper.rb                     # Type creation helpers
+    └── pretty_print_shared_example.rb     # Shared examples
+```
+
+## Test Development Workflow
+
+### For New RBS Features
+
+1. **Create fixture**
+   - Add example Ruby code in `lib/`
+   - Add expected RBS in `sig/`
+   - Optionally add actual (inferred) RBS in `refined/sig/` for mismatch testing
+
+2. **Write unit test**
+   - Test node creation from RBS AST
+   - Test pretty-print output
+   - Test comparison logic
+
+3. **Write integration test**
+   - Test full tree construction
+   - Test metrics calculation
+   - Verify expected behavior
+
+4. **Document coverage**
+   - Update implementation-status.md
+   - Mark feature as implemented
+
+### Test-Driven Development Approach
+
+For implementing type comparison:
+
+1. **Write failing test** showing expected behavior
+2. **Implement minimal code** to make test pass
+3. **Refactor** while keeping tests green
+4. **Add edge cases** and repeat
+
+Example:
+```ruby
+# 1. Write test
+RSpec.describe TypeEvalRb::ComparisonTree::TypeNode do
+  describe '#matches?' do
+    it 'returns true for exact type match' do
+      node = described_class.new(
+        expected: TypeHelper.string,
+        actual: TypeHelper.string
+      )
+      expect(node.matches?).to be true
+    end
+  end
+end
+
+# 2. Implement
+def matches?
+  expected == actual
+end
+
+# 3. Add edge cases
+it 'returns true when actual is untyped' do
+  node = described_class.new(
+    expected: TypeHelper.string,
+    actual: TypeHelper.untyped
+  )
+  expect(node.matches?).to be true
+end
+```
+
+## Continuous Integration
+
+Tests should run on:
+- Multiple Ruby versions (3.3+)
+- Different platforms (Linux, macOS, Windows)
+- Pull requests and main branch
+
+### CI Configuration
+
+```yaml
+# .github/workflows/test.yml
+name: Test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.3', '3.4']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake spec
+      - run: bundle exec rake rubocop
+```
+
+## Coverage Goals
+
+- **Unit test coverage**: Aim for >90%
+- **Integration test coverage**: All major feature combinations
+- **Fixture coverage**: All RBS syntax features
+
+Use SimpleCov to track coverage:
+```ruby
+# spec/spec_helper.rb
+require 'simplecov'
+SimpleCov.start do
+  add_filter '/spec/'
+  add_filter '/vendor/'
+end
+```

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,18 @@ Layout/LineLength:
 Style/Documentation:
   Enabled: false
 
+RSpec/FilePath:
+  Exclude:
+    - 'spec/integration/**/*'
+
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/integration/**/*'
+
+RSpec/DescribeClass:
+  Exclude:
+    - 'spec/integration/**/*'
+
 RSpec/NamedSubject:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ AllCops:
 Metrics/AbcSize:
   Max: 20
 
+Metrics/ClassLength:
+  Max: 120
+
 Metrics/MethodLength:
   Max: 15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+TypeEvalRb is a micro-benchmarking framework for Ruby type inference tools. It compares expected RBS type signatures against actual inferred types using a tree-based comparison structure.
+
+## Development Commands
+
+**Run tests:**
+```bash
+mise exec -- bundle exec rake spec
+```
+
+**Run linter:**
+```bash
+mise exec -- bundle exec rake rubocop
+```
+
+**Run all checks (default):**
+```bash
+mise exec -- bundle exec rake
+```
+
+**Interactive console:**
+```bash
+mise exec -- bin/console
+```
+
+**Note:** This project uses `mise` for Ruby version management. Always prefix commands with `mise exec --` to ensure the correct Ruby version (3.3.1).
+
+## Architecture
+
+The framework consists of two main components:
+
+### Environment (`lib/type_eval_rb/environment.rb`)
+Loads and parses RBS files from a given path using the RBS library. Creates an environment containing class declarations extracted from `.rbs` files.
+
+Key method: `Environment.from_path(path)` - Loads RBS files from `path/sig/*.rbs` and returns an Environment with filtered class declarations.
+
+### ComparisonTree (`lib/type_eval_rb/comparison_tree.rb`)
+Hierarchical tree structure for comparing expected vs actual type signatures. Created via `ComparisonTree.from_envs(expected:, actual:)`.
+
+**Node hierarchy:**
+- `ClassNode` - Compares class-level types
+  - `InstanceVariableNode` - Compares instance variable types
+  - `MethodNode` - Compares method signatures
+    - `ArgumentNode` - Compares parameter types
+    - `TypeNode` - Compares individual type annotations (return types, parameter types)
+
+Each node stores both `expected` and `actual` AST objects from RBS for detailed comparison.
+
+## Test Fixtures
+
+Example RBS signatures and Ruby code are located in `spec/fixtures/examples/`. Each example contains:
+- `lib/*.rb` - Ruby source code
+- `sig/*.rbs` - Expected or actual type signatures
+
+These fixtures are used to test the comparison functionality.
+
+## RuboCop Configuration
+
+- RSpec and Rake cops enabled
+- Ruby 3.3 target
+- Custom metrics limits (ABC: 20, MethodLength: 15)
+- Excludes `spec/fixtures/` from linting
+
+## Documentation
+
+Detailed documentation is available in `.claude/docs/`:
+
+- **[Implementation Status](.claude/docs/implementation-status.md)** - Current implementation status, missing features, and implementation priorities
+- **[RBS Specification](.claude/docs/rbs-specification.md)** - Overview of RBS syntax features that TypeEvalRb needs to support
+- **[Testing Strategy](.claude/docs/testing-strategy.md)** - Testing approach, fixture organization, and test development workflow
+- **[Development Roadmap](.claude/docs/roadmap.md)** - Phased development plan with tasks and acceptance criteria
+
+### Key Insights
+
+**Current State**: The framework has basic tree structure in place but is missing core comparison logic and metrics calculation.
+
+**Immediate Priorities**:
+1. Implement type comparison logic in `TypeNode`
+2. Implement `count_leaf` and `count_matches` in all nodes
+3. Add union type support
+4. Support optional and keyword parameters
+
+**Testing**: Each new feature should include unit tests, integration tests, and corresponding fixtures in `spec/fixtures/examples/`.

--- a/lib/type_eval_rb/comparison_tree.rb
+++ b/lib/type_eval_rb/comparison_tree.rb
@@ -33,6 +33,20 @@ module TypeEvalRb
       @actual = actual
     end
 
+    def count_leaf
+      @class_nodes.sum(&:count_leaf)
+    end
+
+    def count_matches
+      @class_nodes.sum(&:count_matches)
+    end
+
+    def accuracy
+      return 0.0 if count_leaf.zero?
+
+      count_matches.to_f / count_leaf
+    end
+
     def inspect
       "ComparisonTree(class_nodes=#{class_nodes.inspect})"
     end

--- a/lib/type_eval_rb/comparison_tree/argument_node.rb
+++ b/lib/type_eval_rb/comparison_tree/argument_node.rb
@@ -3,12 +3,13 @@
 module TypeEvalRb
   class ComparisonTree
     class ArgumentNode < Node
-      attr_reader :name, :type, :required
+      attr_reader :name, :type, :required, :param_type
 
-      def initialize(name:, type:, required: true)
+      def initialize(name:, type:, required: true, param_type: :positional)
         @name = name
         @type = type
         @required = required
+        @param_type = param_type
         super()
       end
 
@@ -21,7 +22,7 @@ module TypeEvalRb
       end
 
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName
-        q.group(2, "ArgumentNode(name=#{name}, required=#{required}, ") do
+        q.group(2, "ArgumentNode(name=#{name}, required=#{required}, param_type=#{param_type}, ") do
           q.breakable
           q.text('type=')
           q.pp(type)

--- a/lib/type_eval_rb/comparison_tree/argument_node.rb
+++ b/lib/type_eval_rb/comparison_tree/argument_node.rb
@@ -3,11 +3,12 @@
 module TypeEvalRb
   class ComparisonTree
     class ArgumentNode < Node
-      attr_reader :name, :type
+      attr_reader :name, :type, :required
 
-      def initialize(name:, type:)
+      def initialize(name:, type:, required: true)
         @name = name
         @type = type
+        @required = required
         super()
       end
 
@@ -20,7 +21,7 @@ module TypeEvalRb
       end
 
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName
-        q.group(2, "ArgumentNode(name=#{name}, ") do
+        q.group(2, "ArgumentNode(name=#{name}, required=#{required}, ") do
           q.breakable
           q.text('type=')
           q.pp(type)

--- a/lib/type_eval_rb/comparison_tree/argument_node.rb
+++ b/lib/type_eval_rb/comparison_tree/argument_node.rb
@@ -3,13 +3,14 @@
 module TypeEvalRb
   class ComparisonTree
     class ArgumentNode < Node
-      attr_reader :name, :type, :required, :param_type
+      attr_reader :name, :type, :required, :param_type, :rest
 
-      def initialize(name:, type:, required: true, param_type: :positional)
+      def initialize(name:, type:, required: true, param_type: :positional, rest: false)
         @name = name
         @type = type
         @required = required
         @param_type = param_type
+        @rest = rest
         super()
       end
 
@@ -22,7 +23,7 @@ module TypeEvalRb
       end
 
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName
-        q.group(2, "ArgumentNode(name=#{name}, required=#{required}, param_type=#{param_type}, ") do
+        q.group(2, "ArgumentNode(name=#{name}, required=#{required}, param_type=#{param_type}, rest=#{rest}, ") do
           q.breakable
           q.text('type=')
           q.pp(type)

--- a/lib/type_eval_rb/comparison_tree/argument_node.rb
+++ b/lib/type_eval_rb/comparison_tree/argument_node.rb
@@ -11,6 +11,14 @@ module TypeEvalRb
         super()
       end
 
+      def count_leaf
+        @type.count_leaf
+      end
+
+      def count_matches
+        @type.count_matches
+      end
+
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName
         q.group(2, "ArgumentNode(name=#{name}, ") do
           q.breakable

--- a/lib/type_eval_rb/comparison_tree/class_node.rb
+++ b/lib/type_eval_rb/comparison_tree/class_node.rb
@@ -51,6 +51,14 @@ module TypeEvalRb
         super()
       end
 
+      def count_leaf
+        @instance_variable_nodes.sum(&:count_leaf) + @method_nodes.sum(&:count_leaf)
+      end
+
+      def count_matches
+        @instance_variable_nodes.sum(&:count_matches) + @method_nodes.sum(&:count_matches)
+      end
+
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName,Metrics/AbcSize, Metrics/MethodLength
         q.group(2, "ClassNode(typename=#{typename}, ") do
           q.breakable

--- a/lib/type_eval_rb/comparison_tree/class_node.rb
+++ b/lib/type_eval_rb/comparison_tree/class_node.rb
@@ -34,10 +34,13 @@ module TypeEvalRb
           expected.members.select do |member|
             member.is_a?(RBS::AST::Members::MethodDefinition)
           end.map do |expected_method|
+            kind = expected_method.singleton? ? :singleton : :instance
             actual_method = actual.members.find do |member|
-              member.is_a?(RBS::AST::Members::MethodDefinition) && member.name == expected_method.name
+              member.is_a?(RBS::AST::Members::MethodDefinition) &&
+                member.name == expected_method.name &&
+                member.singleton? == expected_method.singleton?
             end
-            MethodNode.from_ast(expected_method.name.to_s, expected_method, actual_method)
+            MethodNode.from_ast(expected_method.name.to_s, expected_method, actual_method, kind:)
           end
         end
       end

--- a/lib/type_eval_rb/comparison_tree/instance_variable_node.rb
+++ b/lib/type_eval_rb/comparison_tree/instance_variable_node.rb
@@ -24,6 +24,14 @@ module TypeEvalRb
         super()
       end
 
+      def count_leaf
+        @type.count_leaf
+      end
+
+      def count_matches
+        @type.count_matches
+      end
+
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName
         q.group(2, "InstanceVariableNode(name=#{name},") do
           q.breakable

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -3,7 +3,7 @@
 module TypeEvalRb
   class ComparisonTree
     class MethodNode < Node
-      attr_reader :name, :parameters, :return_type, :expected, :actual
+      attr_reader :name, :parameters, :return_type, :block, :expected, :actual
 
       class << self
         def from_ast(name, expected, actual)
@@ -11,6 +11,7 @@ module TypeEvalRb
             name:,
             parameters: parameters_to_nodes(expected, actual),
             return_type: return_types_to_node(expected, actual),
+            block: block_to_node(expected, actual),
             expected:,
             actual:
           )
@@ -85,6 +86,14 @@ module TypeEvalRb
           )
         end
 
+        def block_to_node(expected, actual)
+          expected_block = expected.overloads.first.method_type.block
+          return nil unless expected_block
+
+          actual_block = actual&.overloads&.first&.method_type&.block
+          ComparisonTree::TypeNode.new(expected: expected_block, actual: actual_block)
+        end
+
         def return_types_to_node(expected, actual)
           ComparisonTree::TypeNode.new(
             expected: expected.overloads.first.method_type.type.return_type,
@@ -93,21 +102,22 @@ module TypeEvalRb
         end
       end
 
-      def initialize(name:, parameters:, return_type:, expected: nil, actual: nil)
+      def initialize(name:, parameters:, return_type:, block: nil, expected: nil, actual: nil) # rubocop:disable Metrics/ParameterLists
         @name = name
         @parameters = parameters
         @return_type = return_type
+        @block = block
         @expected = expected
         @actual = actual
         super()
       end
 
       def count_leaf
-        @parameters.sum(&:count_leaf) + @return_type.count_leaf
+        @parameters.sum(&:count_leaf) + @return_type.count_leaf + (@block&.count_leaf || 0)
       end
 
       def count_matches
-        @parameters.sum(&:count_matches) + @return_type.count_matches
+        @parameters.sum(&:count_matches) + @return_type.count_matches + (@block&.count_matches || 0)
       end
 
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName,Metrics/MethodLength

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -42,10 +42,25 @@ module TypeEvalRb
             build_keyword_argument_node(kw_name, param, actual_param, required: false)
           end
 
-          required + optional + req_kw + opt_kw
+          rest_pos = if method_type.rest_positionals
+                       actual_rest = actual_method_type&.rest_positionals
+                       [build_argument_node(method_type.rest_positionals, actual_rest, required: false, rest: true)]
+                     else
+                       []
+                     end
+
+          rest_kw = if method_type.rest_keywords
+                      actual_rest_kw = actual_method_type&.rest_keywords
+                      [build_argument_node(method_type.rest_keywords, actual_rest_kw,
+                                           required: false, param_type: :keyword, rest: true)]
+                    else
+                      []
+                    end
+
+          required + optional + rest_pos + req_kw + opt_kw + rest_kw
         end
 
-        def build_argument_node(expected_param, actual_param, required:, param_type: :positional)
+        def build_argument_node(expected_param, actual_param, required:, param_type: :positional, rest: false)
           ComparisonTree::ArgumentNode.new(
             name: expected_param.name.to_s,
             type: ComparisonTree::TypeNode.new(
@@ -53,7 +68,8 @@ module TypeEvalRb
               actual: actual_param ? actual_param.type : nil
             ),
             required:,
-            param_type:
+            param_type:,
+            rest:
           )
         end
 

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -48,6 +48,14 @@ module TypeEvalRb
         super()
       end
 
+      def count_leaf
+        @parameters.sum(&:count_leaf) + @return_type.count_leaf
+      end
+
+      def count_matches
+        @parameters.sum(&:count_matches) + @return_type.count_matches
+      end
+
       def pretty_print(q) # rubocop:disable Naming/MethodParameterName,Metrics/MethodLength
         q.group(2, "MethodNode(name=#{name}, ") do
           q.breakable

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -3,15 +3,16 @@
 module TypeEvalRb
   class ComparisonTree
     class MethodNode < Node
-      attr_reader :name, :parameters, :return_type, :block, :expected, :actual
+      attr_reader :name, :parameters, :return_type, :block, :kind, :expected, :actual
 
       class << self
-        def from_ast(name, expected, actual)
+        def from_ast(name, expected, actual, kind: :instance)
           new(
             name:,
             parameters: parameters_to_nodes(expected, actual),
             return_type: return_types_to_node(expected, actual),
             block: block_to_node(expected, actual),
+            kind:,
             expected:,
             actual:
           )
@@ -102,11 +103,12 @@ module TypeEvalRb
         end
       end
 
-      def initialize(name:, parameters:, return_type:, block: nil, expected: nil, actual: nil) # rubocop:disable Metrics/ParameterLists
+      def initialize(name:, parameters:, return_type:, block: nil, kind: :instance, expected: nil, actual: nil) # rubocop:disable Metrics/ParameterLists
         @name = name
         @parameters = parameters
         @return_type = return_type
         @block = block
+        @kind = kind
         @expected = expected
         @actual = actual
         super()

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -18,7 +18,7 @@ module TypeEvalRb
 
         private
 
-        def parameters_to_nodes(expected, actual) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
+        def parameters_to_nodes(expected, actual) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
           method_type = expected.overloads.first.method_type.type
           actual_method_type = actual&.overloads&.first&.method_type&.type
 
@@ -32,17 +32,40 @@ module TypeEvalRb
             build_argument_node(param, actual_param, required: false)
           end
 
-          required + optional
+          req_kw = method_type.required_keywords.map do |kw_name, param|
+            actual_param = actual_method_type&.required_keywords&.[](kw_name)
+            build_keyword_argument_node(kw_name, param, actual_param, required: true)
+          end
+
+          opt_kw = method_type.optional_keywords.map do |kw_name, param|
+            actual_param = actual_method_type&.optional_keywords&.[](kw_name)
+            build_keyword_argument_node(kw_name, param, actual_param, required: false)
+          end
+
+          required + optional + req_kw + opt_kw
         end
 
-        def build_argument_node(expected_param, actual_param, required:)
+        def build_argument_node(expected_param, actual_param, required:, param_type: :positional)
           ComparisonTree::ArgumentNode.new(
             name: expected_param.name.to_s,
             type: ComparisonTree::TypeNode.new(
               expected: expected_param.type,
               actual: actual_param ? actual_param.type : nil
             ),
-            required:
+            required:,
+            param_type:
+          )
+        end
+
+        def build_keyword_argument_node(kw_name, expected_param, actual_param, required:)
+          ComparisonTree::ArgumentNode.new(
+            name: kw_name.to_s,
+            type: ComparisonTree::TypeNode.new(
+              expected: expected_param.type,
+              actual: actual_param ? actual_param.type : nil
+            ),
+            required:,
+            param_type: :keyword
           )
         end
 

--- a/lib/type_eval_rb/comparison_tree/method_node.rb
+++ b/lib/type_eval_rb/comparison_tree/method_node.rb
@@ -19,16 +19,31 @@ module TypeEvalRb
         private
 
         def parameters_to_nodes(expected, actual) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-          expected.overloads.first.method_type.type.required_positionals.map.with_index do |expected_param, index|
-            actual_param = actual&.overloads&.first&.method_type&.type&.required_positionals&.[](index)
-            ComparisonTree::ArgumentNode.new(
-              name: expected_param.name.to_s,
-              type: ComparisonTree::TypeNode.new(
-                expected: expected_param.type,
-                actual: actual_param ? actual_param.type : nil
-              )
-            )
+          method_type = expected.overloads.first.method_type.type
+          actual_method_type = actual&.overloads&.first&.method_type&.type
+
+          required = method_type.required_positionals.map.with_index do |param, index|
+            actual_param = actual_method_type&.required_positionals&.[](index)
+            build_argument_node(param, actual_param, required: true)
           end
+
+          optional = method_type.optional_positionals.map.with_index do |param, index|
+            actual_param = actual_method_type&.optional_positionals&.[](index)
+            build_argument_node(param, actual_param, required: false)
+          end
+
+          required + optional
+        end
+
+        def build_argument_node(expected_param, actual_param, required:)
+          ComparisonTree::ArgumentNode.new(
+            name: expected_param.name.to_s,
+            type: ComparisonTree::TypeNode.new(
+              expected: expected_param.type,
+              actual: actual_param ? actual_param.type : nil
+            ),
+            required:
+          )
         end
 
         def return_types_to_node(expected, actual)

--- a/lib/type_eval_rb/comparison_tree/type_node.rb
+++ b/lib/type_eval_rb/comparison_tree/type_node.rb
@@ -24,6 +24,14 @@ module TypeEvalRb
         end
       end
 
+      def count_leaf
+        1
+      end
+
+      def count_matches
+        matches? ? 1 : 0
+      end
+
       def matches?
         return true if untyped?(expected) || untyped?(actual)
         return false if actual.nil?

--- a/lib/type_eval_rb/comparison_tree/type_node.rb
+++ b/lib/type_eval_rb/comparison_tree/type_node.rb
@@ -51,6 +51,8 @@ module TypeEvalRb
           actual.is_a?(RBS::Types::ClassInstance) && expected.name == actual.name
         when RBS::Types::Bases::Nil
           actual.is_a?(RBS::Types::Bases::Nil)
+        when RBS::Types::Block
+          actual.is_a?(RBS::Types::Block) && expected.type == actual.type
         else
           expected == actual
         end
@@ -64,6 +66,9 @@ module TypeEvalRb
           'nil'
         when RBS::Types::Bases::Any
           'untyped'
+        when RBS::Types::Block
+          params = type.type.required_positionals.map { |p| type_to_string(p.type) }.join(', ')
+          "{ (#{params}) -> #{type_to_string(type.type.return_type)} }"
         else
           type.to_s
         end

--- a/lib/type_eval_rb/comparison_tree/type_node.rb
+++ b/lib/type_eval_rb/comparison_tree/type_node.rb
@@ -24,12 +24,38 @@ module TypeEvalRb
         end
       end
 
+      def matches?
+        return true if untyped?(expected) || untyped?(actual)
+        return false if actual.nil?
+
+        compare_types(expected, actual)
+      end
+
       private
+
+      def untyped?(type)
+        type.is_a?(RBS::Types::Bases::Any)
+      end
+
+      def compare_types(expected, actual)
+        case expected
+        when RBS::Types::ClassInstance
+          actual.is_a?(RBS::Types::ClassInstance) && expected.name == actual.name
+        when RBS::Types::Bases::Nil
+          actual.is_a?(RBS::Types::Bases::Nil)
+        else
+          expected == actual
+        end
+      end
 
       def type_to_string(type)
         case type
         when RBS::Types::ClassInstance
           type.name.to_s
+        when RBS::Types::Bases::Nil
+          'nil'
+        when RBS::Types::Bases::Any
+          'untyped'
         else
           type.to_s
         end

--- a/lib/type_eval_rb/comparison_tree/type_node.rb
+++ b/lib/type_eval_rb/comparison_tree/type_node.rb
@@ -34,6 +34,7 @@ module TypeEvalRb
 
       def matches?
         return true if untyped?(expected) || untyped?(actual)
+        return true if top?(expected) || bottom?(actual)
         return false if actual.nil?
 
         compare_types(expected, actual)
@@ -45,7 +46,15 @@ module TypeEvalRb
         type.is_a?(RBS::Types::Bases::Any)
       end
 
-      def compare_types(expected, actual)
+      def top?(type)
+        type.is_a?(RBS::Types::Bases::Top)
+      end
+
+      def bottom?(type)
+        type.is_a?(RBS::Types::Bases::Bottom)
+      end
+
+      def compare_types(expected, actual) # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength
         case expected
         when RBS::Types::ClassInstance
           actual.is_a?(RBS::Types::ClassInstance) && expected.name == actual.name
@@ -53,12 +62,47 @@ module TypeEvalRb
           actual.is_a?(RBS::Types::Bases::Nil)
         when RBS::Types::Block
           actual.is_a?(RBS::Types::Block) && expected.type == actual.type
+        when RBS::Types::Union
+          compare_union(expected, actual)
+        when RBS::Types::Optional
+          actual.is_a?(RBS::Types::Optional) &&
+            TypeNode.new(expected: expected.type, actual: actual.type).matches?
+        when RBS::Types::Tuple
+          compare_tuple(expected, actual)
+        when RBS::Types::Intersection
+          compare_intersection(expected, actual)
         else
           expected == actual
         end
       end
 
-      def type_to_string(type)
+      def compare_union(expected, actual)
+        return false unless actual.is_a?(RBS::Types::Union)
+        return false unless expected.types.size == actual.types.size
+
+        expected.types.all? do |exp_t|
+          actual.types.any? { |act_t| TypeNode.new(expected: exp_t, actual: act_t).matches? }
+        end
+      end
+
+      def compare_tuple(expected, actual)
+        return false unless actual.is_a?(RBS::Types::Tuple)
+        return false unless expected.types.size == actual.types.size
+
+        expected.types.zip(actual.types).all? do |exp_t, act_t|
+          TypeNode.new(expected: exp_t, actual: act_t).matches?
+        end
+      end
+
+      def compare_intersection(expected, actual)
+        return false unless actual.is_a?(RBS::Types::Intersection)
+
+        expected.types.all? do |exp_t|
+          actual.types.any? { |act_t| TypeNode.new(expected: exp_t, actual: act_t).matches? }
+        end
+      end
+
+      def type_to_string(type) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
         case type
         when RBS::Types::ClassInstance
           type.name.to_s
@@ -66,6 +110,24 @@ module TypeEvalRb
           'nil'
         when RBS::Types::Bases::Any
           'untyped'
+        when RBS::Types::Bases::Bool
+          'bool'
+        when RBS::Types::Bases::Void
+          'void'
+        when RBS::Types::Bases::Self
+          'self'
+        when RBS::Types::Bases::Top
+          'top'
+        when RBS::Types::Bases::Bottom
+          'bot'
+        when RBS::Types::Union
+          type.types.map { |t| type_to_string(t) }.join(' | ')
+        when RBS::Types::Optional
+          "#{type_to_string(type.type)}?"
+        when RBS::Types::Tuple
+          "[#{type.types.map { |t| type_to_string(t) }.join(', ')}]"
+        when RBS::Types::Intersection
+          type.types.map { |t| type_to_string(t) }.join(' & ')
         when RBS::Types::Block
           params = type.type.required_positionals.map { |p| type_to_string(p.type) }.join(', ')
           "{ (#{params}) -> #{type_to_string(type.type.return_type)} }"

--- a/spec/fixtures/examples/block_params/sig/block_params.rbs
+++ b/spec/fixtures/examples/block_params/sig/block_params.rbs
@@ -1,0 +1,5 @@
+class BlockParams
+  def each: () { (String) -> void } -> void
+
+  def map: () { (String) -> Integer } -> Array[Integer]
+end

--- a/spec/fixtures/examples/keyword_params/sig/keyword_params.rbs
+++ b/spec/fixtures/examples/keyword_params/sig/keyword_params.rbs
@@ -1,0 +1,3 @@
+class KeywordParams
+  def connect: (host: String, port: Integer, ?timeout: Integer) -> bool
+end

--- a/spec/fixtures/examples/optional_params/sig/optional_params.rbs
+++ b/spec/fixtures/examples/optional_params/sig/optional_params.rbs
@@ -1,0 +1,3 @@
+class OptionalParams
+  def greet: (String name, ?String title) -> String
+end

--- a/spec/fixtures/examples/rest_params/sig/rest_params.rbs
+++ b/spec/fixtures/examples/rest_params/sig/rest_params.rbs
@@ -1,0 +1,5 @@
+class RestParams
+  def log: (String level, *String messages) -> void
+
+  def configure: (**Integer options) -> void
+end

--- a/spec/fixtures/examples/singleton_methods/sig/singleton_methods.rbs
+++ b/spec/fixtures/examples/singleton_methods/sig/singleton_methods.rbs
@@ -1,0 +1,5 @@
+class SingletonMethods
+  def self.create: (String name) -> SingletonMethods
+
+  def greet: () -> String
+end

--- a/spec/fixtures/integration/actual/sig/sample.rbs
+++ b/spec/fixtures/integration/actual/sig/sample.rbs
@@ -1,0 +1,7 @@
+class Sample
+  @name: String
+
+  def greet: () -> String
+
+  def count: (Integer n) -> String
+end

--- a/spec/fixtures/integration/expected/sig/sample.rbs
+++ b/spec/fixtures/integration/expected/sig/sample.rbs
@@ -1,0 +1,7 @@
+class Sample
+  @name: String
+
+  def greet: () -> String
+
+  def count: (Integer n) -> Integer
+end

--- a/spec/integration/simple_comparison_spec.rb
+++ b/spec/integration/simple_comparison_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Simple type comparison (integration)' do
+  let(:expected_path) { FixturesHelper.fixture_path('integration/expected') }
+  let(:actual_path)   { FixturesHelper.fixture_path('integration/actual') }
+
+  let(:expected_env) { TypeEvalRb::Environment.from_path(expected_path) }
+  let(:actual_env)   { TypeEvalRb::Environment.from_path(actual_path) }
+
+  let(:tree) { TypeEvalRb::ComparisonTree.from_envs(expected: expected_env, actual: actual_env) }
+
+  describe 'tree structure' do
+    it 'has one class node' do
+      expect(tree.class_nodes.size).to eq(1)
+    end
+
+    it 'has correct class name' do
+      expect(tree.class_nodes.first.typename.to_s).to eq('::Sample')
+    end
+
+    it 'has one instance variable node' do
+      expect(tree.class_nodes.first.instance_variable_nodes.size).to eq(1)
+    end
+
+    it 'has two method nodes' do
+      expect(tree.class_nodes.first.method_nodes.size).to eq(2)
+    end
+  end
+
+  describe 'metrics' do
+    # expected: @name(1) + greet return(1) + count param(1) + count return(1) = 4
+    it 'has correct count_leaf' do
+      expect(tree.count_leaf).to eq(4)
+    end
+
+    # matches: @name(1) + greet return(1) + count param Integer==Integer(1) + count return Integer!=String(0) = 3
+    it 'has correct count_matches' do
+      expect(tree.count_matches).to eq(3)
+    end
+
+    it 'has correct accuracy' do
+      expect(tree.accuracy).to eq(0.75)
+    end
+  end
+end

--- a/spec/support/type_helper.rb
+++ b/spec/support/type_helper.rb
@@ -14,6 +14,14 @@ module TypeHelper
       RBS::Types::ClassInstance.new(name: type_name('::String'), location: nil, args: [])
     end
 
+    def integer
+      RBS::Types::ClassInstance.new(name: type_name('::Integer'), location: nil, args: [])
+    end
+
+    def nil_type
+      RBS::Types::Bases::Nil.new(location: nil)
+    end
+
     def type_node(expected, actual)
       TypeEvalRb::ComparisonTree::TypeNode.new(expected:, actual:)
     end

--- a/spec/support/type_helper.rb
+++ b/spec/support/type_helper.rb
@@ -22,6 +22,42 @@ module TypeHelper
       RBS::Types::Bases::Nil.new(location: nil)
     end
 
+    def bool_type
+      RBS::Types::Bases::Bool.new(location: nil)
+    end
+
+    def void_type
+      RBS::Types::Bases::Void.new(location: nil)
+    end
+
+    def self_type
+      RBS::Types::Bases::Self.new(location: nil)
+    end
+
+    def top_type
+      RBS::Types::Bases::Top.new(location: nil)
+    end
+
+    def bottom_type
+      RBS::Types::Bases::Bottom.new(location: nil)
+    end
+
+    def union_type(*types)
+      RBS::Types::Union.new(types:, location: nil)
+    end
+
+    def optional_type(type)
+      RBS::Types::Optional.new(type:, location: nil)
+    end
+
+    def tuple_type(*types)
+      RBS::Types::Tuple.new(types:, location: nil)
+    end
+
+    def intersection_type(*types)
+      RBS::Types::Intersection.new(types:, location: nil)
+    end
+
     def type_node(expected, actual)
       TypeEvalRb::ComparisonTree::TypeNode.new(expected:, actual:)
     end

--- a/spec/support/type_helper.rb
+++ b/spec/support/type_helper.rb
@@ -37,5 +37,9 @@ module TypeHelper
     def instance_variable_node(name:, type:)
       TypeEvalRb::ComparisonTree::InstanceVariableNode.new(name:, type:)
     end
+
+    def class_node(typename:, instance_variable_nodes:, method_nodes:)
+      TypeEvalRb::ComparisonTree::ClassNode.new(typename:, instance_variable_nodes:, method_nodes:)
+    end
   end
 end

--- a/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
@@ -17,11 +17,23 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
       expect(subject.required).to be true
     end
 
+    it 'defaults param_type to :positional' do
+      expect(subject.param_type).to eq(:positional)
+    end
+
     context 'when required: false' do
       let(:argument_node) { described_class.new(name:, type:, required: false) }
 
       it 'sets required to false' do
         expect(subject.required).to be false
+      end
+    end
+
+    context 'when param_type: :keyword' do
+      let(:argument_node) { described_class.new(name:, type:, param_type: :keyword) }
+
+      it 'sets param_type to :keyword' do
+        expect(subject.param_type).to eq(:keyword)
       end
     end
   end
@@ -42,7 +54,7 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
     let(:node) { argument_node }
 
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
-      ArgumentNode(name=foo, required=true,#{' '}
+      ArgumentNode(name=foo, required=true, param_type=positional,#{' '}
         type=TypeNode( expected="::String", actual="untyped"))
     EXPECTED
   end

--- a/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
       expect(subject.param_type).to eq(:positional)
     end
 
+    it 'defaults rest to false' do
+      expect(subject.rest).to be false
+    end
+
     context 'when required: false' do
       let(:argument_node) { described_class.new(name:, type:, required: false) }
 
@@ -54,7 +58,7 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
     let(:node) { argument_node }
 
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
-      ArgumentNode(name=foo, required=true, param_type=positional,#{' '}
+      ArgumentNode(name=foo, required=true, param_type=positional, rest=false,#{' '}
         type=TypeNode( expected="::String", actual="untyped"))
     EXPECTED
   end

--- a/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
     end
   end
 
+  describe '#count_leaf' do
+    it 'delegates to type.count_leaf' do
+      expect(argument_node.count_leaf).to eq(type.count_leaf)
+    end
+  end
+
+  describe '#count_matches' do
+    it 'delegates to type.count_matches' do
+      expect(argument_node.count_matches).to eq(type.count_matches)
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { argument_node }
 

--- a/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/argument_node_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
       expect(subject.name).to eq(name)
       expect(subject.type).to eq(type)
     end
+
+    it 'defaults required to true' do
+      expect(subject.required).to be true
+    end
+
+    context 'when required: false' do
+      let(:argument_node) { described_class.new(name:, type:, required: false) }
+
+      it 'sets required to false' do
+        expect(subject.required).to be false
+      end
+    end
   end
 
   describe '#count_leaf' do
@@ -30,7 +42,8 @@ RSpec.describe TypeEvalRb::ComparisonTree::ArgumentNode do
     let(:node) { argument_node }
 
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
-      ArgumentNode(name=foo,  type=TypeNode( expected="::String", actual="untyped"))
+      ArgumentNode(name=foo, required=true,#{' '}
+        type=TypeNode( expected="::String", actual="untyped"))
     EXPECTED
   end
 end

--- a/spec/type_eval_rb/comparison_tree/class_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/class_node_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe TypeEvalRb::ComparisonTree::ClassNode do
     end
   end
 
+  describe '#count_leaf' do
+    it 'sums instance_variables and methods leaf counts' do
+      expected = instance_variable_nodes.sum(&:count_leaf) + method_nodes.sum(&:count_leaf)
+      expect(class_node.count_leaf).to eq(expected)
+    end
+  end
+
+  describe '#count_matches' do
+    it 'sums instance_variables and methods match counts' do
+      expected = instance_variable_nodes.sum(&:count_matches) + method_nodes.sum(&:count_matches)
+      expect(class_node.count_matches).to eq(expected)
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { class_node }
 

--- a/spec/type_eval_rb/comparison_tree/instance_variable_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/instance_variable_node_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe TypeEvalRb::ComparisonTree::InstanceVariableNode do
     end
   end
 
+  describe '#count_leaf' do
+    it 'delegates to type.count_leaf' do
+      expect(instance_variable_node.count_leaf).to eq(type.count_leaf)
+    end
+  end
+
+  describe '#count_matches' do
+    it 'delegates to type.count_matches' do
+      expect(instance_variable_node.count_matches).to eq(type.count_matches)
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { instance_variable_node }
 

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -55,13 +55,34 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     end
   end
 
+  describe '.from_ast with keyword parameters' do
+    subject(:node) { described_class.from_ast('connect', method_def, nil) }
+
+    let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('keyword_params')) }
+    let(:class_decl) do
+      env.class_decls[RBS::Namespace.parse('::KeywordParams').to_type_name].decls.first.decl
+    end
+    let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'connect' } }
+
+    it 'parses required keywords with param_type: :keyword and required: true' do
+      req_kw = node.parameters.select { |p| p.param_type == :keyword && p.required }
+      expect(req_kw.map(&:name)).to contain_exactly('host', 'port')
+    end
+
+    it 'parses optional keywords with param_type: :keyword and required: false' do
+      opt_kw = node.parameters.select { |p| p.param_type == :keyword && !p.required }
+      expect(opt_kw.size).to eq(1)
+      expect(opt_kw.first.name).to eq('timeout')
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { method_node }
 
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
       MethodNode(name=foo,#{' '}
         parameters=[
-          ArgumentNode(name=bar, required=true,#{' '}
+          ArgumentNode(name=bar, required=true, param_type=positional,#{' '}
             type=TypeNode( expected="::String", actual="untyped"))
       #{'    '}
         ],

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -55,6 +55,37 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     end
   end
 
+  describe '.from_ast with rest parameters' do
+    let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('rest_params')) }
+    let(:class_decl) do
+      env.class_decls[RBS::Namespace.parse('::RestParams').to_type_name].decls.first.decl
+    end
+
+    context 'with rest positionals (*args)' do
+      subject(:node) { described_class.from_ast('log', method_def, nil) }
+
+      let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'log' } }
+
+      it 'marks rest positional with rest: true' do
+        rest = node.parameters.select(&:rest)
+        expect(rest.size).to eq(1)
+        expect(rest.first.param_type).to eq(:positional)
+      end
+    end
+
+    context 'with rest keywords (**opts)' do
+      subject(:node) { described_class.from_ast('configure', method_def, nil) }
+
+      let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'configure' } }
+
+      it 'marks rest keyword with rest: true and param_type: :keyword' do
+        rest = node.parameters.select(&:rest)
+        expect(rest.size).to eq(1)
+        expect(rest.first.param_type).to eq(:keyword)
+      end
+    end
+  end
+
   describe '.from_ast with keyword parameters' do
     subject(:node) { described_class.from_ast('connect', method_def, nil) }
 
@@ -82,7 +113,7 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
       MethodNode(name=foo,#{' '}
         parameters=[
-          ArgumentNode(name=bar, required=true, param_type=positional,#{' '}
+          ArgumentNode(name=bar, required=true, param_type=positional, rest=false,#{' '}
             type=TypeNode( expected="::String", actual="untyped"))
       #{'    '}
         ],

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
       expect(subject.parameters).to eq(parameters)
       expect(subject.return_type).to eq(return_type)
     end
+
+    it 'defaults kind to :instance' do
+      expect(subject.kind).to eq(:instance)
+    end
   end
 
   describe '#count_leaf' do
@@ -52,6 +56,33 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
       optional = node.parameters.reject(&:required)
       expect(optional.size).to eq(1)
       expect(optional.first.name).to eq('title')
+    end
+  end
+
+  describe '.from_ast with singleton method' do
+    let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('singleton_methods')) }
+    let(:class_decl) do
+      env.class_decls[RBS::Namespace.parse('::SingletonMethods').to_type_name].decls.first.decl
+    end
+
+    context 'with singleton: true' do
+      subject(:node) { described_class.from_ast('create', method_def, nil, kind: :singleton) }
+
+      let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'create' && m.singleton? } }
+
+      it 'sets kind to :singleton' do
+        expect(node.kind).to eq(:singleton)
+      end
+    end
+
+    context 'without singleton flag' do
+      subject(:node) { described_class.from_ast('greet', method_def, nil) }
+
+      let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'greet' && !m.singleton? } }
+
+      it 'defaults kind to :instance' do
+        expect(node.kind).to eq(:instance)
+      end
     end
   end
 

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     end
   end
 
+  describe '#count_leaf' do
+    it 'sums parameters and return_type leaf counts' do
+      expect(method_node.count_leaf).to eq(parameters.sum(&:count_leaf) + return_type.count_leaf)
+    end
+  end
+
+  describe '#count_matches' do
+    it 'sums parameters and return_type match counts' do
+      expect(method_node.count_matches).to eq(parameters.sum(&:count_matches) + return_type.count_matches)
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { method_node }
 

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -55,6 +55,24 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     end
   end
 
+  describe '.from_ast with block parameter' do
+    subject(:node) { described_class.from_ast('each', method_def, nil) }
+
+    let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('block_params')) }
+    let(:class_decl) do
+      env.class_decls[RBS::Namespace.parse('::BlockParams').to_type_name].decls.first.decl
+    end
+    let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'each' } }
+
+    it 'sets block to a TypeNode' do
+      expect(node.block).to be_a(TypeEvalRb::ComparisonTree::TypeNode)
+    end
+
+    it 'includes block in count_leaf' do
+      expect(node.count_leaf).to eq(node.parameters.sum(&:count_leaf) + node.return_type.count_leaf + 1)
+    end
+  end
+
   describe '.from_ast with rest parameters' do
     let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('rest_params')) }
     let(:class_decl) do

--- a/spec/type_eval_rb/comparison_tree/method_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/method_node_spec.rb
@@ -33,13 +33,35 @@ RSpec.describe TypeEvalRb::ComparisonTree::MethodNode do
     end
   end
 
+  describe '.from_ast' do
+    subject(:node) { described_class.from_ast('greet', method_def, nil) }
+
+    let(:env) { TypeEvalRb::Environment.from_path(FixturesHelper.example_path('optional_params')) }
+    let(:class_decl) do
+      env.class_decls[RBS::Namespace.parse('::OptionalParams').to_type_name].decls.first.decl
+    end
+    let(:method_def) { class_decl.members.find { |m| m.name.to_s == 'greet' } }
+
+    it 'parses required positionals with required: true' do
+      required = node.parameters.select(&:required)
+      expect(required.size).to eq(1)
+      expect(required.first.name).to eq('name')
+    end
+
+    it 'parses optional positionals with required: false' do
+      optional = node.parameters.reject(&:required)
+      expect(optional.size).to eq(1)
+      expect(optional.first.name).to eq('title')
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { method_node }
 
     it_behaves_like 'output expected pretty_print', <<~EXPECTED.strip
       MethodNode(name=foo,#{' '}
         parameters=[
-          ArgumentNode(name=bar,#{' '}
+          ArgumentNode(name=bar, required=true,#{' '}
             type=TypeNode( expected="::String", actual="untyped"))
       #{'    '}
         ],

--- a/spec/type_eval_rb/comparison_tree/type_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/type_node_spec.rb
@@ -62,6 +62,162 @@ RSpec.describe TypeEvalRb::ComparisonTree::TypeNode do
     end
   end
 
+  describe '#matches? with composite types' do
+    context 'with identical union types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.union_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.union_type(TypeHelper.string, TypeHelper.integer)
+        )
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with union types in different order' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.union_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.union_type(TypeHelper.integer, TypeHelper.string)
+        )
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with mismatched union types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.union_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.union_type(TypeHelper.string, TypeHelper.nil_type)
+        )
+      end
+
+      it 'returns false' do
+        expect(type_node.matches?).to be false
+      end
+    end
+
+    context 'with identical optional types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.optional_type(TypeHelper.string),
+          actual: TypeHelper.optional_type(TypeHelper.string)
+        )
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with mismatched optional types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.optional_type(TypeHelper.string),
+          actual: TypeHelper.optional_type(TypeHelper.integer)
+        )
+      end
+
+      it 'returns false' do
+        expect(type_node.matches?).to be false
+      end
+    end
+
+    context 'with identical tuple types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.tuple_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.tuple_type(TypeHelper.string, TypeHelper.integer)
+        )
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with different-length tuple types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.tuple_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.tuple_type(TypeHelper.string)
+        )
+      end
+
+      it 'returns false' do
+        expect(type_node.matches?).to be false
+      end
+    end
+
+    context 'with identical intersection types' do
+      let(:type_node) do
+        described_class.new(
+          expected: TypeHelper.intersection_type(TypeHelper.string, TypeHelper.integer),
+          actual: TypeHelper.intersection_type(TypeHelper.string, TypeHelper.integer)
+        )
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with bool type' do
+      let(:type_node) do
+        described_class.new(expected: TypeHelper.bool_type, actual: TypeHelper.bool_type)
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with void type' do
+      let(:type_node) do
+        described_class.new(expected: TypeHelper.void_type, actual: TypeHelper.void_type)
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with self type' do
+      let(:type_node) do
+        described_class.new(expected: TypeHelper.self_type, actual: TypeHelper.self_type)
+      end
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with top type' do
+      let(:type_node) do
+        described_class.new(expected: TypeHelper.top_type, actual: TypeHelper.string)
+      end
+
+      it 'returns true (top matches everything)' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'with bottom type' do
+      let(:type_node) do
+        described_class.new(expected: TypeHelper.string, actual: TypeHelper.bottom_type)
+      end
+
+      it 'returns true (bottom is subtype of all)' do
+        expect(type_node.matches?).to be true
+      end
+    end
+  end
+
   describe '#count_leaf' do
     it 'returns 1' do
       expect(type_node.count_leaf).to eq(1)

--- a/spec/type_eval_rb/comparison_tree/type_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/type_node_spec.rb
@@ -62,6 +62,30 @@ RSpec.describe TypeEvalRb::ComparisonTree::TypeNode do
     end
   end
 
+  describe '#count_leaf' do
+    it 'returns 1' do
+      expect(type_node.count_leaf).to eq(1)
+    end
+  end
+
+  describe '#count_matches' do
+    context 'when types match' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: TypeHelper.string) }
+
+      it 'returns 1' do
+        expect(type_node.count_matches).to eq(1)
+      end
+    end
+
+    context 'when types do not match' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: TypeHelper.integer) }
+
+      it 'returns 0' do
+        expect(type_node.count_matches).to eq(0)
+      end
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { type_node }
 

--- a/spec/type_eval_rb/comparison_tree/type_node_spec.rb
+++ b/spec/type_eval_rb/comparison_tree/type_node_spec.rb
@@ -12,6 +12,56 @@ RSpec.describe TypeEvalRb::ComparisonTree::TypeNode do
     end
   end
 
+  describe '#matches?' do
+    context 'when expected and actual are identical ClassInstance types' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: TypeHelper.string) }
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'when actual is untyped' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: TypeHelper.undefined) }
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'when expected is untyped' do
+      let(:type_node) { described_class.new(expected: TypeHelper.undefined, actual: TypeHelper.string) }
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'when expected is nil type and actual is nil type' do
+      let(:type_node) { described_class.new(expected: TypeHelper.nil_type, actual: TypeHelper.nil_type) }
+
+      it 'returns true' do
+        expect(type_node.matches?).to be true
+      end
+    end
+
+    context 'when expected and actual are different ClassInstance types' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: TypeHelper.integer) }
+
+      it 'returns false' do
+        expect(type_node.matches?).to be false
+      end
+    end
+
+    context 'when actual is nil' do
+      let(:type_node) { described_class.new(expected: TypeHelper.string, actual: nil) }
+
+      it 'returns false' do
+        expect(type_node.matches?).to be false
+      end
+    end
+  end
+
   describe '#pretty_print' do
     let(:node) { type_node }
 

--- a/spec/type_eval_rb/comparison_tree_spec.rb
+++ b/spec/type_eval_rb/comparison_tree_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe TypeEvalRb::ComparisonTree do
+  let(:type_matching) { TypeHelper.type_node(TypeHelper.string, TypeHelper.string) }
+  let(:type_mismatching) { TypeHelper.type_node(TypeHelper.string, TypeHelper.integer) }
+
+  let(:class_nodes) do
+    [
+      TypeHelper.class_node(
+        typename: RBS::Namespace.parse('::Foo').to_type_name,
+        instance_variable_nodes: [],
+        method_nodes: [
+          TypeHelper.method_node(name: :bar, parameters: [], return_type: type_matching),
+          TypeHelper.method_node(name: :baz, parameters: [], return_type: type_mismatching)
+        ]
+      )
+    ]
+  end
+
+  let(:tree) { described_class.new(class_nodes:) }
+
+  describe '#count_leaf' do
+    it 'sums all class_nodes leaf counts' do
+      expect(tree.count_leaf).to eq(class_nodes.sum(&:count_leaf))
+    end
+  end
+
+  describe '#count_matches' do
+    it 'sums all class_nodes match counts' do
+      expect(tree.count_matches).to eq(class_nodes.sum(&:count_matches))
+    end
+  end
+
+  describe '#accuracy' do
+    it 'returns count_matches / count_leaf as Float' do
+      expect(tree.accuracy).to eq(tree.count_matches.to_f / tree.count_leaf)
+    end
+
+    context 'when count_leaf is 0' do
+      let(:class_nodes) { [] }
+
+      it 'returns 0.0' do
+        expect(tree.accuracy).to eq(0.0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

Phase 1〜3 の実装。TypeEvalRb の中核となる型比較ロジック・メトリクス計算・型システムカバレッジを追加。

## 変更の背景

フレームワークはツリー構造のみ存在し、型比較もメトリクス計算も未実装だった。ベンチマークとして機能するために、これらのコア機能が必要。

## 変更詳細

### Phase 1: 型比較ロジックとメトリクス
- `TypeNode#matches?` を実装（ClassInstance 完全一致、untyped は万能一致、nil 型比較）
- `TypeNode#count_leaf` / `#count_matches` を実装
- `ArgumentNode`, `InstanceVariableNode`, `MethodNode`, `ClassNode` に `count_leaf` / `count_matches` を追加
- `ComparisonTree#count_leaf` / `#count_matches` / `#accuracy` を追加
- 統合テスト `spec/integration/simple_comparison_spec.rb` を追加（fixture ベース end-to-end テスト）

### Phase 2: メソッドシグネチャ対応
- `ArgumentNode` に `required`, `param_type`, `rest` 属性を追加
- `MethodNode.from_ast` でオプション位置引数・キーワード引数（必須/オプション）・rest 引数・ブロック引数を解析
- `MethodNode` に `block` 属性（TypeNode or nil）と `kind`（:instance/:singleton）を追加
- `ClassNode.methods_to_nodes` でシングルトンメソッドを区別して収集
- 各パラメータ種別のフィクスチャ（optional_params / keyword_params / rest_params / block_params / singleton_methods）を追加

### Phase 3: 型システムカバレッジ
- `TypeNode#matches?` に Union（順序非依存）・Optional・Tuple・Intersection 比較を追加
- top 型は全ての expected にマッチ、bottom 型は全ての actual にマッチ
- `type_to_string` に Bool, Void, Self, Top, Bot, Union, Optional, Tuple, Intersection, Block の変換を追加